### PR TITLE
Bug 1446236 - Allow customizing link to bug writing guidelines

### DIFF
--- a/extensions/BMO/template/en/default/bug/create/create-web-bounty.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-web-bounty.html.tmpl
@@ -88,7 +88,7 @@ function validateAndSubmit() {
   <input type="hidden" name="token" value="[% token FILTER html %]">
 
 <div class="head_desc">
-  <a href="https://developer.mozilla.org/docs/Mozilla/QA/Bug_writing_guidelines">
+  <a href="[% terms.BugWritingGuidelinesURL %]">
     [% terms.Bug %] writing guidelines</a>
 </div>
 

--- a/extensions/BMO/template/en/default/bug/create/user-message.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/user-message.html.tmpl
@@ -17,7 +17,7 @@
   [% END +%]
   [% UNLESS no_bug_guidelines %]
     Before reporting a [% terms.bug %], make sure you've read our
-    <a href="https://developer.mozilla.org/docs/Mozilla/QA/Bug_writing_guidelines">
+    <a href="[% terms.BugWritingGuidelinesURL %]">
     [% terms.bug %] writing guidelines</a> and double checked that your [% terms.bug %] hasn't already
     been reported. Consult our list of <a href="https://bugzilla.mozilla.org/duplicates.cgi">
     most frequently reported [% terms.bugs %]</a> and <a href="https://bugzilla.mozilla.org/query.cgi">

--- a/extensions/BMO/template/en/default/pages/bug-writing.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/bug-writing.html.tmpl
@@ -7,5 +7,5 @@
   #%]
 
 [% PROCESS global/redirect.html.tmpl
-   url = "https://developer.mozilla.org/docs/Mozilla/QA/Bug_writing_guidelines"
+   url = "[% terms.BugWritingGuidelinesURL %]"
 %]

--- a/extensions/BMO/template/en/default/pages/etiquette.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/etiquette.html.tmpl
@@ -173,7 +173,7 @@
 <h2>See Also</h2>
 
 <p>
-  <a href="https://developer.mozilla.org/docs/Mozilla/QA/Bug_writing_guidelines">The [% terms.Bug %] Writing Guidelines</a>.
+  <a href="[% terms.BugWritingGuidelinesURL %]">The [% terms.Bug %] Writing Guidelines</a>.
 </p>
 
 [% INCLUDE global/footer.html.tmpl %]

--- a/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
+++ b/extensions/GuidedBugEntry/template/en/default/guided/guided.html.tmpl
@@ -356,7 +356,7 @@ Product: <b><span id="dupes_product_name">?</span></b>:
 <ul>
 <li>Please fill out this form clearly, precisely and in as much detail as you can manage.</li>
 <li>Please report only a single problem at a time.</li>
-<li><a href="https://developer.mozilla.org/docs/Mozilla/QA/Bug_writing_guidelines" target="_blank" rel="noopener noreferrer">These guidelines</a>
+<li><a href="[% terms.BugWritingGuidelinesURL %]" target="_blank" rel="noopener noreferrer">These guidelines</a>
 explain how to write effective [% terms.bug %] reports.</li>
 </ul>
 

--- a/template/en/default/bug/create/user-message.html.tmpl
+++ b/template/en/default/bug/create/user-message.html.tmpl
@@ -30,7 +30,7 @@
 [% PROCESS global/variables.none.tmpl %]
 
 Before reporting [% terms.abug %], please read the 
-<a href="https://developer.mozilla.org/docs/Mozilla/QA/Bug_writing_guidelines">
+<a href="[% terms.BugWritingGuidelinesURL %]">
 [% terms.bug %] writing guidelines</a>, please look at the list of
 <a href="duplicates.cgi">most frequently reported [% terms.bugs %]</a>, and please
 <a href="query.cgi">search</a> for the [% terms.bug %].

--- a/template/en/default/bug/new_bug.html.tmpl
+++ b/template/en/default/bug/new_bug.html.tmpl
@@ -27,7 +27,7 @@
         <h2>Create New [% terms.Bug %]</h2>
         <p>
           Before reporting a [% terms.bug %], make sure you've read our
-          <a href="https://developer.mozilla.org/docs/Mozilla/QA/Bug_writing_guidelines">
+          <a href="[% terms.BugWritingGuidelinesURL %]">
           [% terms.bug %] writing guidelines</a> and double checked that your [% terms.bug %] hasn't already
           been reported. Consult our list of <a href="https://bugzilla.mozilla.org/duplicates.cgi">
           most frequently reported [% terms.bugs %]</a> and <a href="https://bugzilla.mozilla.org/query.cgi">

--- a/template/en/default/global/variables.none.tmpl
+++ b/template/en/default/global/variables.none.tmpl
@@ -37,7 +37,9 @@
   "bugs" => "bugs",
   "Bugs" => "Bugs",
   "zeroSearchResults" => "Zarro Boogs found",
-  "Bugzilla" => "Bugzilla"
+  "Bugzilla" => "Bugzilla",
+
+  "BugWritingGuidelinesURL" => "https://developer.mozilla.org/docs/Mozilla/QA/Bug_writing_guidelines",
   }
 %]
 

--- a/template/en/default/index.html.tmpl
+++ b/template/en/default/index.html.tmpl
@@ -75,7 +75,7 @@
                 <a href="page.cgi?id=etiquette.html">[%- terms.Bugzilla %] Etiquette</a>
               </li>
               <li>
-                | <a href="https://developer.mozilla.org/docs/Mozilla/QA/Bug_writing_guidelines">[%- terms.Bug %] Writing Guidelines</a>
+                | <a href="[% terms.BugWritingGuidelinesURL %]">[%- terms.Bug %] Writing Guidelines</a>
               </li>
               [% Hook.process('additional_links') %]
             </ul>


### PR DESCRIPTION
This URL occurs in a number of places, so it's a good candidate for customization.

Not sure if the terms (`variables.none.tmpl`) is the best place to add it to, though.