### PR TITLE
Bug 1446236 - Allow customizing the name of the "nobody" user (nobody@mozilla.org)

### DIFF
--- a/Bugzilla/Config/General.pm
+++ b/Bugzilla/Config/General.pm
@@ -25,6 +25,14 @@ use constant get_param_list => (
     },
 
     {
+        name     => 'nobody_user',
+        type     => 't',
+        no_reset => '1',
+        default  => 'nobody@mozilla.org',
+        checker  => \&check_email
+    },
+
+    {
         name    => 'docs_urlbase',
         type    => 't',
         default => 'docs/%lang%/html/',

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -3895,7 +3895,7 @@ sub _migrate_group_owners {
     my $dbh = Bugzilla->dbh;
     return if $dbh->bz_column_info('groups', 'owner_user_id');
     $dbh->bz_add_column('groups', 'owner_user_id', {TYPE => 'INT3'});
-    my $nobody = Bugzilla::User->check('nobody@mozilla.org');
+    my $nobody = Bugzilla::User->check(Bugzilla->params->{'nobody_user'});
     $dbh->do('UPDATE groups SET owner_user_id = ?', undef, $nobody->id);
 }
 

--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -826,7 +826,7 @@ sub object_end_of_create {
         # Add default searches to new user's footer
         my $dbh = Bugzilla->dbh;
 
-        my $sharer = Bugzilla::User->new({ name => 'nobody@mozilla.org' })
+        my $sharer = Bugzilla::User->new({ name => Bugzilla->params->{'nobody_user'} })
             or return;
         my $group = Bugzilla::Group->new({ name => 'everyone' })
             or return;
@@ -867,7 +867,7 @@ sub _bug_reporters_hw_os {
 sub _bug_is_unassigned {
     my ($self) = @_;
     my $assignee = $self->assigned_to->login;
-    return $assignee eq 'nobody@mozilla.org' || $assignee =~ /\.bugs$/;
+    return $assignee eq Bugzilla->params->{'nobody_user'} || $assignee =~ /\.bugs$/;
 }
 
 sub _bug_has_current_patch {
@@ -1021,7 +1021,7 @@ sub object_start_of_update {
 
     # and the assignee isn't a real person
     return unless
-        $new_bug->assigned_to->login eq 'nobody@mozilla.org'
+        $new_bug->assigned_to->login eq Bugzilla->params->{'nobody_user'}
         || $new_bug->assigned_to->login =~ /\.bugs$/;
 
     # and the user can set the status to NEW
@@ -1394,7 +1394,7 @@ sub field_end_of_create {
     my $name = $field->name;
 
     if (Bugzilla->usage_mode == USAGE_MODE_CMDLINE) {
-        Bugzilla->set_user(Bugzilla::User->check({ name => 'nobody@mozilla.org' }));
+        Bugzilla->set_user(Bugzilla::User->check({ name => Bugzilla->params->{'nobody_user'} }));
         print "Creating IT permission grant bug for new field '$name'...";
     }
 
@@ -1772,7 +1772,7 @@ sub _post_employee_incident_bug {
     my ($investigate_bug, $ssh_key_bug);
     my $old_user = Bugzilla->user;
     eval {
-        Bugzilla->set_user(Bugzilla::User->new({ name => 'nobody@mozilla.org' }));
+        Bugzilla->set_user(Bugzilla::User->new({ name => Bugzilla->params->{'nobody_user'} }));
         my $new_user = Bugzilla->user;
 
         # HACK: User needs to be in the editbugs and primary bug's group to allow

--- a/extensions/BMO/bin/bug_1093952.pl
+++ b/extensions/BMO/bin/bug_1093952.pl
@@ -52,7 +52,7 @@ printf "About to fix %s bugs\n", scalar(@$bugs);
 print "Press <Ctrl-C> to stop or <Enter> to continue...\n";
 getc();
 
-my $nobody = Bugzilla::User->check({ name => 'nobody@mozilla.org' });
+my $nobody = Bugzilla::User->check({ name => Bugzilla->params->{'nobody_user'} });
 my $field  = Bugzilla::Field->check({ name => 'status_whiteboard' });
 my $when   = $dbh->selectrow_array('SELECT LOCALTIMESTAMP(0)');
 

--- a/extensions/BMO/bin/bug_1141452.pl
+++ b/extensions/BMO/bin/bug_1141452.pl
@@ -50,7 +50,7 @@ printf "About to fix %s bugs\n", scalar(@$flags);
 print "Press <Ctrl-C> to stop or <Enter> to continue...\n";
 getc();
 
-my $nobody = Bugzilla::User->check({ name => 'nobody@mozilla.org' });
+my $nobody = Bugzilla::User->check({ name => Bugzilla->params->{'nobody_user'} });
 my $when   = $dbh->selectrow_array('SELECT LOCALTIMESTAMP(0)');
 
 $dbh->bz_start_transaction();

--- a/extensions/BMO/bin/migrate-github-pull-requests.pl
+++ b/extensions/BMO/bin/migrate-github-pull-requests.pl
@@ -23,7 +23,7 @@ use Bugzilla::User;
 use Bugzilla::Util qw(trim);
 
 my $dbh = Bugzilla->dbh;
-my $nobody = Bugzilla::User->check({ name => 'nobody@mozilla.org' });
+my $nobody = Bugzilla::User->check({ name => Bugzilla->params->{'nobody_user'} });
 my $field = Bugzilla::Field->check({ name => 'attachments.mimetype' });
 
 # grab list of suitable attachments

--- a/extensions/BMO/template/en/default/bug/create/create-mozpr.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-mozpr.html.tmpl
@@ -297,7 +297,7 @@ function validate_form() {
 <input type="hidden" name="version" value="unspecified">
 <input type="hidden" name="bug_severity" value="normal">
 <input type="hidden" name="group" value="pr-private">
-<input type="hidden" name="assigned_to" id="assigned_to" value="nobody@mozilla.org">
+<input type="hidden" name="assigned_to" id="assigned_to" value="[% Bugzilla.params.nobody_user %]">
 <input type="hidden" name="token" value="[% token FILTER html %]">
 
 <div class="head">

--- a/extensions/BMO/template/en/default/bug/create/create-poweredby.html.tmpl
+++ b/extensions/BMO/template/en/default/bug/create/create-poweredby.html.tmpl
@@ -43,7 +43,7 @@ please provide some information about your application or product.</p>
         <input type="hidden" name="priority" value="--">
         <input type="hidden" name="op_sys" value="Other">
         <input type="hidden" name="version" value="unspecified">
-        <input type="hidden" name="assigned_to" value="nobody@mozilla.org">
+        <input type="hidden" name="assigned_to" value="[% Bugzilla.params.nobody_user %]">
         <input type="hidden" name="cc" value="liz@mozilla.com">
         <input type="hidden" name="groups" value="marketing-private">
         <input type="hidden" name="token" value="[% token FILTER html %]">

--- a/extensions/BMO/template/en/default/pages/group_admins.html.tmpl
+++ b/extensions/BMO/template/en/default/pages/group_admins.html.tmpl
@@ -39,7 +39,7 @@
             [% group.name FILTER html %]</span>
         </td>
         <td nowrap>
-          [% IF group.owner.login == 'nobody@mozilla.org' %]
+          [% IF group.owner.login == Bugzilla.params.nobody_user %]
             &ndash;
           [% ELSE %]
             [% INCLUDE global/user.html.tmpl who = group.owner %]

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -19,7 +19,7 @@
 
   # these are used in a few places
   is_cced = bug.cc.contains(user.login);
-  unassigned = (bug.assigned_to.login == "nobody@mozilla.org")
+  unassigned = (bug.assigned_to.login == Bugzilla.params.nobody_user)
                || (bug.assigned_to.login.search('\.bugs$'));
 
   # custom fields that have custom rendering, or should not be rendered

--- a/extensions/ComponentWatching/Extension.pm
+++ b/extensions/ComponentWatching/Extension.pm
@@ -23,7 +23,7 @@ use Bugzilla::Util qw(detaint_natural trim trick_taint);
 our $VERSION = '2';
 
 use constant REQUIRE_WATCH_USER => 1;
-use constant DEFAULT_ASSIGNEE   => 'nobody@mozilla.org';
+use constant DEFAULT_ASSIGNEE   => Bugzilla->params->{'nobody_user'};
 
 use constant REL_COMPONENT_WATCHER => 15;
 

--- a/extensions/PhabBugz/lib/Util.pm
+++ b/extensions/PhabBugz/lib/Util.pm
@@ -128,7 +128,7 @@ sub get_bug_role_phids {
 
     my @bug_users = ( $bug->reporter );
     push(@bug_users, $bug->assigned_to)
-        if $bug->assigned_to->email !~ /^nobody\@mozilla\.org$/;
+        if $bug->assigned_to->email != Bugzilla->params->{'nobody_user'};
     push(@bug_users, $bug->qa_contact) if $bug->qa_contact;
     push(@bug_users, @{ $bug->cc_users }) if @{ $bug->cc_users };
 

--- a/extensions/Review/bin/migrate_mentor_from_whiteboard.pl
+++ b/extensions/Review/bin/migrate_mentor_from_whiteboard.pl
@@ -36,7 +36,7 @@ EOF
 <>;
 
 # we need to be logged in to do user searching and update bugs
-my $nobody = Bugzilla::User->check({ name => 'nobody@mozilla.org' });
+my $nobody = Bugzilla::User->check({ name => Bugzilla->params->{'nobody_user'} });
 $nobody->{groups} = [ Bugzilla::Group->get_all ];
 Bugzilla->set_user($nobody);
 

--- a/extensions/Review/lib/WebService.pm
+++ b/extensions/Review/lib/WebService.pm
@@ -51,7 +51,7 @@ sub suggestions {
         # we always need to be authentiated to perform user matching
         my $user = Bugzilla->user;
         if (!$user->id) {
-            Bugzilla->set_user(Bugzilla::User->check({ name => 'nobody@mozilla.org' }));
+            Bugzilla->set_user(Bugzilla::User->check({ name => Bugzilla->params->{'nobody_user'} }));
             push @reviewers, @{ $bug->mentors };
             Bugzilla->set_user($user);
         } else {

--- a/extensions/TrackingFlags/bin/bug_825946.pl
+++ b/extensions/TrackingFlags/bin/bug_825946.pl
@@ -24,7 +24,7 @@ use Bugzilla::Bug qw(LogActivityEntry);
 
 Bugzilla->usage_mode(USAGE_MODE_CMDLINE);
 my $dbh = Bugzilla->dbh;
-my $user = Bugzilla::User->check({name => 'nobody@mozilla.org'});
+my $user = Bugzilla::User->check({name => Bugzilla->params->{'nobody_user'}});
 
 my $tf_vis = $dbh->selectall_arrayref(<<SQL);
     SELECT

--- a/extensions/TrackingFlags/bin/bulk_flag_clear.pl
+++ b/extensions/TrackingFlags/bin/bulk_flag_clear.pl
@@ -110,7 +110,7 @@ if (!$config->{update_db}) {
 
 # update bugs
 
-my $nobody = Bugzilla::User->check({ name => 'nobody@mozilla.org' });
+my $nobody = Bugzilla::User->check({ name => Bugzilla->params->{'nobody_user'} });
 # put our nobody user into all groups to avoid permissions issues
 $nobody->{groups} = [Bugzilla::Group->get_all];
 Bugzilla->set_user($nobody);

--- a/scripts/eject-users-from-groups.pl
+++ b/scripts/eject-users-from-groups.pl
@@ -23,7 +23,7 @@ Bugzilla->usage_mode(USAGE_MODE_CMDLINE);
 
 my $dbh = Bugzilla->dbh;
 my @remove_group_names;
-my $nobody_name = 'nobody@mozilla.org';
+my $nobody_name = Bugzilla->params->{'nobody_user'};
 my $admin_name = 'automation@bmo.tld';
 
 GetOptions(

--- a/scripts/generate_bmo_data.pl
+++ b/scripts/generate_bmo_data.pl
@@ -158,7 +158,7 @@ $group->update();
 
 my @users = (
     {
-        login    => 'nobody@mozilla.org',
+        login    => Bugzilla->params->{'nobody_user'},
         realname => 'Nobody; OK to take it and work on it',
         password => '*'
     },
@@ -267,7 +267,7 @@ my @products = (
                 name           => 'General',
                 description    => 'For bugs in Firefox which do not fit into ' .
                                   'other more specific Firefox components',
-                initialowner   => 'nobody@mozilla.org',
+                initialowner   => Bugzilla->params->{'nobody_user'},
                 initialqaowner => '',
                 initial_cc     => [],
                 watch_user     => 'general@firefox.bugs'
@@ -287,7 +287,7 @@ my @products = (
                 name           => 'General',
                 description    => 'This is the component for issues specific to bugzilla.mozilla.org '
                                .  'that do not belong in other components.',
-                initialowner   => 'nobody@mozilla.org',
+                initialowner   => Bugzilla->params->{'nobody_user'},
                 initialqaowner => '',
                 initial_cc     => [],
                 watch_user     => 'general@bugzilla.bugs'

--- a/scripts/move_os.pl
+++ b/scripts/move_os.pl
@@ -40,7 +40,7 @@ my $dbh       = Bugzilla->dbh;
 my $timestamp = $dbh->selectrow_array('SELECT LOCALTIMESTAMP(0)');
 my $bug_ids   = $dbh->selectcol_arrayref(q{SELECT bug_id FROM bugs WHERE bugs.op_sys = ?}, undef, $from_os);
 my $field     = Bugzilla::Field->check({ name => 'op_sys', cache => 1 });
-my $nobody    = Bugzilla::User->check({ name => 'nobody@mozilla.org', cache => 1 });
+my $nobody    = Bugzilla::User->check({ name => Bugzilla->params->{'nobody_user'}, cache => 1 });
 
 my $bug_count = @$bug_ids;
 if ($bug_count == 0) {

--- a/scripts/movebugs.pl
+++ b/scripts/movebugs.pl
@@ -73,10 +73,12 @@ my $component_field_id = $dbh->selectrow_array(
 $component_field_id
     or die "Can't find field ID for 'component' field\n";
 
+my $nobody = Bugzilla->params->{'nobody_user'};
 my $user_id = $dbh->selectrow_array(
-    "SELECT userid FROM profiles WHERE login_name='nobody\@mozilla.org'");
+    "SELECT userid FROM profiles WHERE login_name=?",
+    undef, $nobody);
 $user_id
-    or die "Can't find user ID for 'nobody\@mozilla.org'\n";
+    or die "Can't find user ID for '$nobody'\n";
 
 $dbh->bz_start_transaction();
 

--- a/scripts/nagios_blocker_checker.pl
+++ b/scripts/nagios_blocker_checker.pl
@@ -28,7 +28,7 @@ my $config = {
     assignee        => '',
     product         => '',
     component       => '',
-    unassigned      => 'nobody@mozilla.org',
+    unassigned      => Bugzilla->params->{'nobody_user'},
     # severities
     severity        => 'major,critical,blocker',
     # time in hours to wait before paging/warning

--- a/scripts/remove_idle_group_members.pl
+++ b/scripts/remove_idle_group_members.pl
@@ -78,7 +78,7 @@ foreach my $group_id (keys %remove_data) {
     $dbh->bz_commit_transaction();
 
     # nobody@mozilla.org cannot recieve email
-    next if $group->owner->login eq 'nobody@mozilla.org';
+    next if $group->owner->login eq Bugzilla->params->{'nobody_user'};
 
     _send_email($group, \@users_removed);
 }

--- a/scripts/reset_default_user.pl
+++ b/scripts/reset_default_user.pl
@@ -52,7 +52,7 @@ if (!$product || $help
 }
 
 # We will need these for entering into bugs_activity
-my $who   = Bugzilla::User->new({ name => 'nobody@mozilla.org' });
+my $who   = Bugzilla::User->new({ name => Bugzilla->params->{'nobody_user'} });
 my $field = Bugzilla::Field->new({ name => $field_name });
 
 trick_taint($product);

--- a/t/bmo/comments.t
+++ b/t/bmo/comments.t
@@ -35,7 +35,7 @@ my $bug_1 = Bugzilla::Bug->create(
         keywords     => [],
         cc           => [],
         comment      => 'This is a brand new bug',
-        assigned_to  => 'nobody@mozilla.org',
+        assigned_to  => Bugzilla->params->{'nobody_user'},
     }
 );
 ok($bug_1->id, "got a new bug");
@@ -55,7 +55,7 @@ my $bug_2 = Bugzilla::Bug->create(
         keywords     => [],
         cc           => [],
         comment      => "This is related to ${urlbase}show_bug.cgi?id=$bug_1_id",
-        assigned_to  => 'nobody@mozilla.org',
+        assigned_to  => Bugzilla->params->{'nobody_user'},
     }
 );
 

--- a/template/en/default/attachment/create.html.tmpl
+++ b/template/en/default/attachment/create.html.tmpl
@@ -83,7 +83,7 @@ TUI_hide_default('attachment_text_field');
         <td>
           <em>If you want to assign this [% terms.bug %] to yourself,
               check the box below.</em><br>
-          [% IF bug.assigned_to.login == "nobody@mozilla.org" || bug.assigned_to.login.search('.bugs$') %]
+          [% IF bug.assigned_to.login == Bugzilla.params.nobody_user || bug.assigned_to.login.search('.bugs$') %]
             [% take_if_patch = 1 %]
           [% END %]
           <input type="checkbox" id="takebug" name="takebug" value="1" [% IF take_if_patch %] data-take-if-patch="1" [% END %]>


### PR DESCRIPTION
Previously hard-coded to `nobody@mozilla.org`.