### PR TITLE
Bug 1446236 - table.html.tmpl: Use order_columns only when present

### DIFF
--- a/template/en/default/list/table.html.tmpl
+++ b/template/en/default/list/table.html.tmpl
@@ -90,7 +90,9 @@
       <th class="sorttable_nosort">&nbsp;</th>
       [% END %]
       <th colspan="[% splitheader ? 2 : 1 %]" class="first-child
-                   sorted_[% lsearch(order_columns, 'bug_id') FILTER html %]">
+                   [% order_columns.defined
+                      ? 'sorted_' _ lsearch(order_columns, 'bug_id')
+                      : '' FILTER html %]">
         <a href="buglist.cgi?
                   [% urlquerypart FILTER html %]&amp;order=
                   [% PROCESS new_order id='bug_id' %]
@@ -136,7 +138,9 @@
 [% BLOCK columnheader %]
   <th colspan="[% splitheader ? 2 : 1 %]"
       class="sortable_column_[% key FILTER html %]
-             sorted_[% lsearch(order_columns, id) FILTER html %]">
+             [% order_columns.defined
+                ? 'sorted_' _ lsearch(order_columns, id)
+                : '' FILTER html %]">
     <a href="buglist.cgi?[% urlquerypart FILTER html %]&amp;order=
       [% PROCESS new_order %]
       [%-#%]&amp;query_based_on=


### PR DESCRIPTION
Fix a hard dependency on the BMO extension.

order_columns is set in `Bugzilla::Extension::BMO`, which might not be present / loaded.