### PR TITLE
Bug 1446236 - BugModal: Use TrackingFlags only when present

### DIFF
--- a/extensions/BugModal/Extension.pm
+++ b/extensions/BugModal/Extension.pm
@@ -188,10 +188,13 @@ sub template_before_process {
     return if exists $bug->{error};
 
     # trigger loading of tracking flags
-    Bugzilla::Extension::TrackingFlags->template_before_process({
-        file => 'bug/edit.html.tmpl',
-        vars => $vars,
-    });
+    state $have_tracking_flags = any { $_->NAME eq 'TrackingFlags' } @{ Bugzilla->extensions };
+    if ($have_tracking_flags) {
+        Bugzilla::Extension::TrackingFlags->template_before_process({
+            file => 'bug/edit.html.tmpl',
+            vars => $vars,
+        });
+    }
 
     if (any { $bug->product eq $_ } READABLE_BUG_STATUS_PRODUCTS) {
         my @flags = map { { name => $_->name, status => $_->status } } @{$bug->flags};


### PR DESCRIPTION
Allows using the BugModal extension without the TrackingFlags extension.

As with #24.

Maybe there's a better way to do this, like a hook?

Also, should I be prepending the bug number ("Bug 1446236 -") to my PRs / commit messages?