### PR TITLE
Bug 1446236 - error pages fixups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,9 @@
 /data
 /localconfig
 /localconfig.*
+/conf/env.conf
 /index.html
+/errors/
 /error_reports
 /.DS_Store
 /template_cache

--- a/Bugzilla/Install/Filesystem.pm
+++ b/Bugzilla/Install/Filesystem.pm
@@ -475,6 +475,7 @@ sub FILESYSTEM {
     );
 
     # Create static error pages.
+    $create_dirs{"errors"} = DIR_CGI_READ;
     $create_files{"errors/401.html"} = {
         perms     => CGI_READ,
         overwrite => 1,


### PR DESCRIPTION
Sorry, #28 was incomplete. Now that the directory has been emptied, it won't be in git, so we must create it.

Update `.gitignore` as well.