### PR TITLE
Bug 1446236 - Add & use simpler method to check if an extension is present

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -248,6 +248,19 @@ sub extensions {
     return $cache->{extensions};
 }
 
+sub have_extension {
+    my ($class, $name) = @_;
+    my $cache = $class->request_cache;
+    if (!$cache->{extensions_hash}) {
+        my %extensions;
+        foreach (@{ $class->extensions}) {
+            @extensions{$_->NAME} = ();
+        }
+        $cache->{extensions_hash} = \%extensions;
+    }
+    return exists $cache->{extensions_hash}{$name};
+}
+
 sub cgi {
     return $_[0]->request_cache->{cgi} ||= new Bugzilla::CGI();
 }

--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -233,6 +233,11 @@ sub template_inner {
 
 sub extensions {
     my ($class) = @_;
+
+    state $recursive = 0;
+    die "Recursive attempt to load/query extensions" if $recursive;
+    $recursive = 1;
+
     my $cache = $class->request_cache;
     if (!$cache->{extensions}) {
         my $extension_packages = Bugzilla::Extension->load_all();
@@ -245,6 +250,7 @@ sub extensions {
         }
         $cache->{extensions} = \@extensions;
     }
+    $recursive = 0;
     return $cache->{extensions};
 }
 

--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -234,6 +234,10 @@ sub template_inner {
 sub extensions {
     my ($class) = @_;
 
+    # Guard against extensions querying the extension list during initialization
+    # (through this method or has_extension).
+    # The extension list is not fully populated at that point,
+    # so the results would not be meaningful.
     state $recursive = 0;
     die "Recursive attempt to load/query extensions" if $recursive;
     $recursive = 1;

--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -258,10 +258,7 @@ sub have_extension {
     my ($class, $name) = @_;
     my $cache = $class->request_cache;
     if (!$cache->{extensions_hash}) {
-        my %extensions;
-        foreach (@{ $class->extensions}) {
-            @extensions{$_->NAME} = ();
-        }
+        my %extensions = map { $_->NAME => 1 } @{ Bugzilla->extensions };
         $cache->{extensions_hash} = \%extensions;
     }
     return exists $cache->{extensions_hash}{$name};

--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -254,7 +254,7 @@ sub extensions {
     return $cache->{extensions};
 }
 
-sub have_extension {
+sub has_extension {
     my ($class, $name) = @_;
     my $cache = $class->request_cache;
     if (!$cache->{extensions_hash}) {

--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -34,7 +34,6 @@ use Date::Format;
 use Date::Parse;
 use Scalar::Util qw(blessed);
 use List::MoreUtils qw(all firstidx part uniq);
-use List::Util qw(any);
 use POSIX qw(INT_MAX);
 use Storable qw(dclone);
 use Time::HiRes qw(gettimeofday tv_interval);
@@ -803,8 +802,7 @@ sub data {
     # BMO - to avoid massive amounts of joins, if we're selecting a lot of
     # tracking flags, replace them with placeholders. the values will be
     # retrieved later and injected into the result.
-    state $have_tracking_flags = any { $_->NAME eq 'TrackingFlags' } @{ Bugzilla->extensions };
-    if ($have_tracking_flags) {
+    if (Bugzilla->have_extension('TrackingFlags')) {
         my %tf_map = map { $_ => 1 } Bugzilla::Extension::TrackingFlags::Flag->get_all_names();
         my @tf_selected = grep { exists $tf_map{$_} } @orig_fields;
         # mysql has a limit of 61 joins, and we want to avoid massive amounts of joins
@@ -867,7 +865,7 @@ sub data {
     $self->{data} = [map { $data{$_} } @$bug_ids];
 
     # BMO - get tracking flags values, and insert into result
-    if ($have_tracking_flags && @{ $self->{tracking_flags} }) {
+    if (Bugzilla->have_extension('TrackingFlags') && @{ $self->{tracking_flags} }) {
         # read values
         my $values;
         $sql = "

--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -802,7 +802,7 @@ sub data {
     # BMO - to avoid massive amounts of joins, if we're selecting a lot of
     # tracking flags, replace them with placeholders. the values will be
     # retrieved later and injected into the result.
-    if (Bugzilla->have_extension('TrackingFlags')) {
+    if (Bugzilla->has_extension('TrackingFlags')) {
         my %tf_map = map { $_ => 1 } Bugzilla::Extension::TrackingFlags::Flag->get_all_names();
         my @tf_selected = grep { exists $tf_map{$_} } @orig_fields;
         # mysql has a limit of 61 joins, and we want to avoid massive amounts of joins
@@ -865,7 +865,7 @@ sub data {
     $self->{data} = [map { $data{$_} } @$bug_ids];
 
     # BMO - get tracking flags values, and insert into result
-    if (Bugzilla->have_extension('TrackingFlags') && @{ $self->{tracking_flags} }) {
+    if (Bugzilla->has_extension('TrackingFlags') && @{ $self->{tracking_flags} }) {
         # read values
         my $values;
         $sql = "

--- a/extensions/BugModal/Extension.pm
+++ b/extensions/BugModal/Extension.pm
@@ -188,7 +188,7 @@ sub template_before_process {
     return if exists $bug->{error};
 
     # trigger loading of tracking flags
-    if (Bugzilla->have_extension('TrackingFlags')) {
+    if (Bugzilla->has_extension('TrackingFlags')) {
         Bugzilla::Extension::TrackingFlags->template_before_process({
             file => 'bug/edit.html.tmpl',
             vars => $vars,

--- a/extensions/BugModal/Extension.pm
+++ b/extensions/BugModal/Extension.pm
@@ -188,8 +188,7 @@ sub template_before_process {
     return if exists $bug->{error};
 
     # trigger loading of tracking flags
-    state $have_tracking_flags = any { $_->NAME eq 'TrackingFlags' } @{ Bugzilla->extensions };
-    if ($have_tracking_flags) {
+    if (Bugzilla->have_extension('TrackingFlags')) {
         Bugzilla::Extension::TrackingFlags->template_before_process({
             file => 'bug/edit.html.tmpl',
             vars => $vars,

--- a/votes.cgi
+++ b/votes.cgi
@@ -30,8 +30,7 @@ use lib qw(. lib local/lib/perl5);
 use Bugzilla;
 use Bugzilla::Error;
 
-my $is_enabled = grep { $_->NAME eq 'Voting' } @{ Bugzilla->extensions };
-$is_enabled || ThrowCodeError('extension_disabled', { name => 'Voting' });
+Bugzilla->have_extension('Voting') || ThrowCodeError('extension_disabled', { name => 'Voting' });
 
 my $cgi = Bugzilla->cgi;
 my $action = $cgi->param('action') || 'show_user';

--- a/votes.cgi
+++ b/votes.cgi
@@ -30,7 +30,7 @@ use lib qw(. lib local/lib/perl5);
 use Bugzilla;
 use Bugzilla::Error;
 
-Bugzilla->have_extension('Voting') || ThrowCodeError('extension_disabled', { name => 'Voting' });
+Bugzilla->has_extension('Voting') || ThrowCodeError('extension_disabled', { name => 'Voting' });
 
 my $cgi = Bugzilla->cgi;
 my $action = $cgi->param('action') || 'show_user';


### PR DESCRIPTION
Ideally these should probably all be refactored into extension-agnostic hooks, but for the time being simplify the code a little.

This adds `extensions_hash` as a separate variable to `request_cache`. An alternative would be to change `$cache->{extensions} ` to a hash, however as hashes are unsorted, I was worried that it could introduce unwanted effects due to the iteration order being changed.