### PR TITLE
Bug 1446236 - Fix instant search without GuidedBugEntry

### DIFF
--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -994,6 +994,8 @@ sub create {
 
             'feature_enabled' => sub { return Bugzilla->feature(@_); },
 
+            'has_extension' => sub { return Bugzilla->has_extension(@_); },
+
             # field_descs can be somewhat slow to generate, so we generate
             # it only once per-language no matter how many times
             # $template->process() is called.

--- a/js/instant-search.js
+++ b/js/instant-search.js
@@ -189,7 +189,7 @@ YAHOO.bugzilla.instantSearch = {
     var result = [];
     var name = Dom.get('product').value;
     result.push(name);
-    if (products[name] && products[name].related) {
+    if (typeof products !== 'undefined' && products[name] && products[name].related) {
       for (var i = 0, n = products[name].related.length; i < n; i++) {
         result.push(products[name].related[i]);
       }

--- a/js/instant-search.js
+++ b/js/instant-search.js
@@ -138,7 +138,7 @@ YAHOO.bugzilla.instantSearch = {
 
       YAHOO.bugzilla.instantSearch.dataTable.showTableMessage(
         'Searching...&nbsp;&nbsp;&nbsp;' +
-        '<img src="extensions/GuidedBugEntry/web/images/throbber.gif"' + 
+        '<img src="images/throbber.gif"' +
         ' width="16" height="11">',
         YAHOO.widget.DataTable.CLASS_LOADING
       );

--- a/template/en/default/search/search-instant.html.tmpl
+++ b/template/en/default/search/search-instant.html.tmpl
@@ -8,11 +8,15 @@
 
 [% PROCESS global/variables.none.tmpl %]
 
+[% javascript_urls = [ 'js/instant-search.js' ] %]
+[% IF has_extension('GuidedBugEntry') %]
+  [% javascript_urls.import(['extensions/GuidedBugEntry/web/js/products.js']); %]
+[% END %]
+
 [% PROCESS global/header.html.tmpl 
   title = "Instant Search"
   generate_api_token = 1
-  javascript_urls = [ 'extensions/GuidedBugEntry/web/js/products.js',
-                      'js/instant-search.js', ]
+  javascript_urls = javascript_urls
 %]
 
 [% UNLESS default.exists('product') && default.product.size %]


### PR DESCRIPTION
Instant search had a little bit of hard-coded references to GuidedBugEntry's products.js.

Refactor these so GuidedBugEntry can gracefully inject the product synonyms remains a TODO, but for now, allow instant search to work on its own.