### PR TITLE
Move lbheartbeat out of BMO

### DIFF
--- a/Bugzilla/Install/Filesystem.pm
+++ b/Bugzilla/Install/Filesystem.pm
@@ -329,6 +329,8 @@ sub FILESYSTEM {
   # The name of each file, pointing at its default permissions and
   # default contents.
   my %create_files = (
+    "__lbheartbeat__" => {perms => CGI_READ, contents => 'httpd OK'},
+
     "$datadir/extensions/additional" => {perms => CGI_READ, contents => ''},
 
     # We create this file so that it always has the right owner

--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -2524,12 +2524,6 @@ sub install_filesystem {
   my $files          = $args->{files};
   my $create_files   = $args->{create_files};
   my $extensions_dir = bz_locations()->{extensionsdir};
-  $create_files->{__lbheartbeat__} = {
-    perms => Bugzilla::Install::Filesystem::WS_SERVE,
-    overwrite => 1,            # the original value for this was wrong, overwrite it
-    contents  => 'httpd OK',
-  };
-
 
   # version.json needs to have a source attribute pointing to
   # our repository. We already have this information in the (static)


### PR DESCRIPTION
This would cause startup to fail when the BMO extension was disabled,
as assert_httpd would fail to test the __lbheartbeat__ endpoint.