### PR TITLE
Fix header covering up announcements

### DIFF
--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -978,8 +978,6 @@ input[type="radio"]:checked {
   }
 
   #header {
-    height: 48px;
-    position: fixed;
     width: 100%;
     z-index: 5;
   }


### PR DESCRIPTION
The "position:fixed" rule caused the header to cover up:

- The noscript message
- The "Please enable two-factor authentication" message
- The announcehtml param (if configured)
