### PR TITLE
default security group name is undef when it does not exist

### DIFF
--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -2481,7 +2481,9 @@ sub _group_always_settable {
 }
 
 sub _default_security_group {
-  return $_[0]->default_security_group_obj->name;
+  my $security_group = $_[0]->default_security_group_obj;
+
+  return defined($security_group) ? $security_group->name : undef;
 }
 
 sub _default_security_group_obj {


### PR DESCRIPTION
The BMO extension provides a default security group to products. I think
this is a good feature that should be core'd. In the meantime, there is
no default security group for the initial data set, so this makes it so
that when there isn't one, when the name is looked up it isn't an error.