### PR TITLE
.github/workflows/release: Remove libgd3 version constraint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           sudo apt-get install --ignore-hold --allow-downgrades -y \
               build-essential curl libssl-dev zlib1g-dev openssl \
               libexpat-dev cmake git libcairo-dev libgd-dev \
-              default-libmysqlclient-dev unzip wget libgd3=2.2.5-5.2ubuntu2
+              default-libmysqlclient-dev unzip wget libgd3
       - name: cpm install
         run: |
           perl Makefile.PL


### PR DESCRIPTION
Try to fix CI.

(Creating a pull request because: )
https://github.com/bugzilla/harmony/blob/5734288cdacbbd907a8196e60f304d84a09f3f41/.github/workflows/release.yml#L8-L11