### PR TITLE
checksetup: Print a message explaining a possible failure mode

### DIFF
--- a/checksetup.pl
+++ b/checksetup.pl
@@ -134,6 +134,11 @@ exit 0 if $switch{'check-modules'};
 # then instead of our nice normal checksetup message, the user would
 # get a cryptic Perl error about the missing module.
 
+print "About to try loading Bugzilla.\n";
+print "If you get an error such as\n";
+print "\"Compilation failed in require at " . __FILE__ . " line " . (__LINE__ + 3) . "\" below,\n";
+print "please re-run checksetup.pl.\n\n";
+
 require Bugzilla;
 require Bugzilla::User;
 


### PR DESCRIPTION
#### Details
Sometimes checksetup fails at the `require Bugzilla` line (as is explained in the pre-existing comment).

In this failure mode, the cause of the problem is not obvious.

Print a little message beforehand to guide users who encounter this situation.

#### Additional info
N/A

#### Test Plan
Not sure what exact conditions trigger this specific failure.
