### PR TITLE
ensure SQL querys from FlagTypeComment are valid

### DIFF
--- a/extensions/FlagTypeComment/Extension.pm
+++ b/extensions/FlagTypeComment/Extension.pm
@@ -72,7 +72,7 @@ sub _set_ftc_states {
   my $dbh = Bugzilla->dbh;
 
   my $ftc_flags;
-  my $db_result;
+  my $db_result = [];
   if ($file =~ /^admin\//) {
 
     # admin
@@ -121,11 +121,13 @@ sub _set_ftc_states {
 
     my $types = join(',', map { $_->id } @$flag_types);
     my $states = "'" . join("','", FLAGTYPE_COMMENT_STATES) . "'";
-    $db_result = $dbh->selectall_arrayref(
-      "SELECT type_id AS flagtype, on_status AS state, comment AS text
-               FROM flagtype_comments
-              WHERE type_id IN ($types) AND on_status IN ($states)", {Slice => {}}
-    );
+    if ($types) {
+      $db_result = $dbh->selectall_arrayref(
+        "SELECT type_id AS flagtype, on_status AS state, comment AS text
+                 FROM flagtype_comments
+                WHERE type_id IN ($types) AND on_status IN ($states)", {Slice => {}}
+      );
+    }
   }
 
   foreach my $row (@$db_result) {


### PR DESCRIPTION
#### Details
<!-- Explain what you did -->
This PR fixes the attachment upload. Then `$types` is empty the SQL query is malformed.

#### Test Plan
1. Open the show_bug view
2. Edit the bug
3. Click _Attach New File_

