### PR TITLE
[harmony] Bug 1852497: Use actions/checkout@v4 in GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Cache CPAN packages
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
See [Bug 1852497](https://bugzilla.mozilla.org/show_bug.cgi?id=1852497)
