### PR TITLE
fix rst in doc

### DIFF
--- a/docs/en/rst/integrating/auth0.rst
+++ b/docs/en/rst/integrating/auth0.rst
@@ -5,18 +5,20 @@ Adding an Auth0 Custom Social Integration
 
 Bugzilla can be added as a 'Custom Social Connection'.
 
-====================  ============================================      ======================================================
+====================  ===============================================   ======================================================
 Parameter             Example(s)                                        Notes
---------------------  --------------------------------------------      ------------------------------------------------------
-Name                  BMO-Stage                                         Whatever makes you happy
+--------------------  -----------------------------------------------   ------------------------------------------------------
+Name                  Bugzilla-Stage                                    Memorable name for the connection
 Client ID             aaaaaaaaaaaaaaaaaaaa                              Ask your Bugzilla admin to create one for you.
 Client Secret         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa          Same as above.
 Authorization URL     https://bugzilla.allizom.org/oauth/authorize      Note the HTTP client must use the correct HOST header.
 Token URL             https://bugzilla.allizom.org/oauth/access_token   (none)
 Scope                 user:read                                         As of this writing, this is the only scope available.
 Fetch User Profile    (see below)                                       (none)
+====================  ===============================================   ======================================================
 
-.. code-block:: javascript
+.. code-block:: js
+
   function (access_token, ctx, callback) {
     request.get('https://bugzilla.allizom.org/api/user/profile', {
       'headers': {


### PR DESCRIPTION
#### Details
Fixes rst syntax errors

#### Additional info
- Run `perl makedocs.pl` from `docs/`
- Get warning:
```
/home/ech/src/harmony/docs/en/rst/integrating/auth0.rst:8: WARNING: Malformed table.
No bottom table border found.
```
- Observe that `docs/en/html/integrating/auth0.html` is incomplete 
- The first error hides a code block formatting error

__Note there are other warnings when `makedocs.pl` is run but they do not result in incomplete files

#### Test Plan
Run `perl makedocs.pl` and warnings about table are gone and confirm output in `docs/en/html`
