### PR TITLE
Apikey html tmpl

### DIFF
--- a/docs/en/rst/integrating/auth0.rst
+++ b/docs/en/rst/integrating/auth0.rst
@@ -5,18 +5,20 @@ Adding an Auth0 Custom Social Integration
 
 Bugzilla can be added as a 'Custom Social Connection'.
 
-====================  ============================================      ======================================================
+====================  ===============================================   ======================================================
 Parameter             Example(s)                                        Notes
---------------------  --------------------------------------------      ------------------------------------------------------
-Name                  BMO-Stage                                         Whatever makes you happy
+--------------------  -----------------------------------------------   ------------------------------------------------------
+Name                  Bugzilla-Stage                                    Memorable name for the connection
 Client ID             aaaaaaaaaaaaaaaaaaaa                              Ask your Bugzilla admin to create one for you.
 Client Secret         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa          Same as above.
 Authorization URL     https://bugzilla.allizom.org/oauth/authorize      Note the HTTP client must use the correct HOST header.
 Token URL             https://bugzilla.allizom.org/oauth/access_token   (none)
 Scope                 user:read                                         As of this writing, this is the only scope available.
 Fetch User Profile    (see below)                                       (none)
+====================  ===============================================   ======================================================
 
-.. code-block:: javascript
+.. code-block:: js
+
   function (access_token, ctx, callback) {
     request.get('https://bugzilla.allizom.org/api/user/profile', {
       'headers': {

--- a/template/en/default/account/prefs/apikey.html.tmpl
+++ b/template/en/default/account/prefs/apikey.html.tmpl
@@ -18,7 +18,7 @@
 </p>
 <p>
   Documentation on how to log in is available
-  <a href="https://bmo.readthedocs.io/en/latest/api/core/v1/general.html#authentication">
+  <a href="https://bugzilla.readthedocs.io/en/latest/api/core/v1/general.html#authentication">
     here</a>.
 </p>
 


### PR DESCRIPTION
#### Details
Template points at bmo, not bugzilla docs. This PR fixes this.