### PR TITLE
1446236: update default user email, point to bugzilla docs not bmo

### DIFF
--- a/conf/checksetup_answers.txt
+++ b/conf/checksetup_answers.txt
@@ -1,4 +1,4 @@
-$answer{'ADMIN_EMAIL'}          = 'admin@bmo.test';
+$answer{'ADMIN_EMAIL'}          = 'admin@bugzilla.test';
 $answer{'ADMIN_OK'}             = 'Y';
 $answer{'ADMIN_PASSWORD'}       = 'password01!';
 $answer{'passwdqc_min'}         = '8, 8, 8, 8, 8';
@@ -26,5 +26,5 @@ $answer{'default_bug_type'}     = '--';
 $answer{'defaultpriority'}      = '--';
 $answer{'defaultseverity'}      = 'normal';
 $answer{'skin'}                 = 'Mozilla';
-$answer{'docs_urlbase'}         = 'https://bmo.readthedocs.io/en/latest/';
+$answer{'docs_urlbase'}         = 'https://bugzilla.readthedocs.io/en/latest/';
 $answer{'db_mysql_ssl_get_pubkey'} = 1;

--- a/docker/development.md
+++ b/docker/development.md
@@ -18,7 +18,7 @@ Settings](https://support.mozilla.org/en-US/kb/connection-settings-firefox).
 The procedure should be similar for other browsers.
 
 After that, you should be able to visit <http://bmo.test/> from your
-browser. You can login as <admin@bmo.test> with the password
+browser. You can login as <admin@bugzilla.test> with the password
 `password01!`.
 
 If you want to update the code running in the web container, you do not

--- a/extensions/Webhooks/template/en/default/pages/webhooks.html.tmpl
+++ b/extensions/Webhooks/template/en/default/pages/webhooks.html.tmpl
@@ -94,7 +94,7 @@ content every change made in the [% terms.bug %].</p>
       "time": "2020-07-24T20:11:22",
       "user": {
           "id": 1,
-            "login": "admin@bmo.test",
+            "login": "admin@bugzilla.test",
             "real_name": "Vagrant User"
       },
       "changes": [
@@ -135,11 +135,11 @@ content every change made in the [% terms.bug %].</p>
       "reporter": {
             "id": 1,
             "real_name": "Vagrant User",
-            "login": "admin@bmo.test"
+            "login": "admin@bugzilla.test"
       },
       "assigned_to": {
           "id": 1,
-            "login": "admin@bmo.test",
+            "login": "admin@bugzilla.test",
             "real_name": "Vagrant User"
         },
       "platform": "PC",
@@ -165,7 +165,7 @@ content every change made in the [% terms.bug %].</p>
       "time": "2020-07-24T20:11:22",
       "user": {
           "id": 1,
-            "login": "admin@bmo.test",
+            "login": "admin@bugzilla.test",
             "real_name": "Vagrant User"
       },
 },

--- a/scripts/entrypoint.pl
+++ b/scripts/entrypoint.pl
@@ -123,7 +123,7 @@ sub cmd_dev_httpd {
     run(
       'perl', 'scripts/generate_bmo_data.pl',
       '--param' => 'use_mailer_queue=0',
-      'admin@bmo.test'
+      'admin@bugzilla.test'
     );
   }
 


### PR DESCRIPTION
#### Details
This PR updates the email of the default user, and updates the home page to point at bugzilla, not bmo docs.