### PR TITLE
Bug 1874564: QuickSearch inputs need labels

### DIFF
--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -301,7 +301,7 @@
         <input role="searchbox" id="quicksearch_top" class="dropdown-button" name="quicksearch" autocomplete="off"
                value="[% quicksearch FILTER html %]" placeholder="Search [% terms.Bugs %]"
                title="Enter a [% terms.bug %] number or some search terms" aria-controls="header-search-dropdown"
-               aria-label="Quick Search">
+               aria-labelledby="header-search-label">
         [% PROCESS "global/header-search-dropdown.html.tmpl" %]
       </section>
     </form>

--- a/template/en/default/index.html.tmpl
+++ b/template/en/default/index.html.tmpl
@@ -86,6 +86,7 @@
           <div>
             <input id="quicksearch_main" type="text" name="quicksearch" autofocus
               placeholder="Enter [% terms.abug %] number or some search terms"
+              aria-label="Quick Search"
               title="Quick Search">
             <input id="find" type="submit" value="Quick Search">
             <ul class="additional_links" id="quicksearch_links">

--- a/template/en/default/index.html.tmpl
+++ b/template/en/default/index.html.tmpl
@@ -86,7 +86,7 @@
           <div>
             <input id="quicksearch_main" type="text" name="quicksearch" autofocus
               placeholder="Enter [% terms.abug %] number or some search terms"
-              aria-label="Quick Search"
+              aria-labelledby="find"
               title="Quick Search">
             <input id="find" type="submit" value="Quick Search">
             <ul class="additional_links" id="quicksearch_links">

--- a/template/en/default/pages/quicksearch.html.tmpl
+++ b/template/en/default/pages/quicksearch.html.tmpl
@@ -32,7 +32,7 @@
 
 <form name="f" action="[% basepath FILTER none %]buglist.cgi" method="get"
       class='quicksearch_check_empty' data-no-csrf>
-  <input type="text" size="40" name="quicksearch" aria-label="Quick Search">
+  <input type="text" size="40" name="quicksearch" aria-labelledby="find">
   <input type="submit" value="Search" id="find">
 </form>
 

--- a/template/en/default/pages/quicksearch.html.tmpl
+++ b/template/en/default/pages/quicksearch.html.tmpl
@@ -32,7 +32,7 @@
 
 <form name="f" action="[% basepath FILTER none %]buglist.cgi" method="get"
       class='quicksearch_check_empty' data-no-csrf>
-  <input type="text" size="40" name="quicksearch">
+  <input type="text" size="40" name="quicksearch" aria-label="Quick Search">
   <input type="submit" value="Search" id="find">
 </form>
 


### PR DESCRIPTION
#### Details
Add aria-labelledby to Quicksearch boxes

#### Additional info
* [bmo#1874564](https://bugzilla.mozilla.org/show_bug.cgi?id=1874564)
