### PR TITLE
Bug 1896338: properly detect if the DB already exists during setup

### DIFF
--- a/Bugzilla/DB.pm
+++ b/Bugzilla/DB.pm
@@ -335,7 +335,7 @@ sub bz_create_database {
   my $dbh;
 
   # See if we can connect to the actual Bugzilla database.
-  my $conn_success = eval { $dbh = connect_main() };
+  my $conn_success = eval { $dbh = connect_main(); $dbh->ping(); };
   my $db_name      = Bugzilla->localconfig->db_name;
 
   if (!$conn_success) {


### PR DESCRIPTION
#### Additional info
* [bmo#1896338](https://bugzilla.mozilla.org/show_bug.cgi?id=1896338)
