### PR TITLE
Bug 1905521: Temporary fix for deprecated Postgres Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: docker compose -f docker-compose.test-mariadb.yml run -e CI=1 bugzilla6.test test_bmo -q -f t/bmo/*.t
 
   test_bugzilla6_pg:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - name: Install docker-compose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - name: Install docker-compose
+      - name: Install docker-compose docker.io
         run: sudo apt update && sudo apt install -y docker-compose
       - name: Build the Docker images
-        run: docker compose -f docker-compose.test-pg.yml build
+        run: docker-compose -f docker-compose.test-pg.yml build
       - name: Run bmo specific tests
-        run: docker compose -f docker-compose.test-pg.yml run -e CI=1 bugzilla6.test test_bmo -q -f t/bmo/*.t
+        run: docker-compose -f docker-compose.test-pg.yml run -e CI=1 bugzilla6.test test_bmo -q -f t/bmo/*.t
 
   test_bugzilla6_sqlite:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - name: Install docker-compose docker.io
-        run: sudo apt update && sudo apt install -y docker-compose
+      - name: Install docker-compose
+        run: sudo apt update && sudo apt install -y docker-compose docker.io
       - name: Build the Docker images
         run: docker-compose -f docker-compose.test-pg.yml build
       - name: Run bmo specific tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: docker compose -f docker-compose.test-mariadb.yml run -e CI=1 bugzilla6.test test_bmo -q -f t/bmo/*.t
 
   test_bugzilla6_pg:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install docker-compose


### PR DESCRIPTION
#### Details
<!-- Explain what you did -->
Use ubuntu-22.04 instead of ubuntu-latest for Pg test

#### Additional info
* [bug#1905521](https://bugzilla.mozilla.org/show_bug.cgi?id=1905521)

