### PR TITLE
[harmony] Bug 1902375: fix foreignkey error upgrading from <3.0 to >=5.0.6

### DIFF
--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -923,7 +923,7 @@ sub _update_flagtypes_id {
     }
   }
 
-  if ($flagtypes_def->{TYPE} eq 'SMALLSERIAL') {
+  if ($flagtypes_def->{TYPE} ne 'MEDIUMSERIAL') {
     $flagtypes_def->{TYPE} = 'MEDIUMSERIAL';
     $dbh->bz_alter_column('flagtypes', 'id', $flagtypes_def);
   }


### PR DESCRIPTION
<!--

#### Instructions

1. All pull requests to an officially supported branch must be accompanied by a bug report on bugzilla.mozilla.org. Please stop and file one there if you haven't already, or look for an existing one that fits what you're doing (the bug entry form will automatically search for things that look similar to the Summary you enter).
   File a bug report: https://bugzilla.mozilla.org/enter_bug.cgi?product=Bugzilla
2. GitHub will automatically attach your pull request to the bug report in Bugzilla if you have "Bug #######" in the title of the pull request, where ####### is the bug number. For readability, we recommend putting it at the beginning of the title.
3. If it's not otherwise obvious from the title which branch the pull request applies to, please put the name of the branch in square brackets at the beginning of the title.

 Example title:
   [5.2] Bug 1234: Change Foo to do Bar
-->

#### Details
<!-- Explain what you did -->
Fix foreign key reference error.

#### Additional info
<!-- Paste the bug number after the # and after the = in the following line. -->
* [bug#1902375](https://bugzilla.mozilla.org/show_bug.cgi?id=1902375)

#### Test Plan
<!-- How did you verify the fix/feature in steps -->
1. Install Bugzilla 2.18rc3 on MySQL 5.7
2. mysqldump the database and restore it to MariaDB 10.6
3. Install Harmony and point it at the MariaDB instance
4. run checksetup.pl

NOTE: Harmony upgrade from older versions is broken in general right now.  But this fix is still valid, and will be one step closer to having it working.
