### PR TITLE
Bug 2052640: Allow more than 32k components (port from 5.x)

### DIFF
--- a/Bugzilla/DB/Schema.pm
+++ b/Bugzilla/DB/Schema.pm
@@ -266,7 +266,7 @@ use constant ABSTRACT_SCHEMA => {
       },
       version      => {TYPE => 'varchar(64)', NOTNULL => 1},
       component_id => {
-        TYPE       => 'INT2',
+        TYPE       => 'INT3',
         NOTNULL    => 1,
         REFERENCES => {TABLE => 'components', COLUMN => 'id'}
       },
@@ -730,7 +730,7 @@ use constant ABSTRACT_SCHEMA => {
         REFERENCES => {TABLE => 'products', COLUMN => 'id', DELETE => 'CASCADE'}
       },
       component_id => {
-        TYPE       => 'INT2',
+        TYPE       => 'INT3',
         REFERENCES => {TABLE => 'components', COLUMN => 'id', DELETE => 'CASCADE'}
       },
     ],
@@ -752,7 +752,7 @@ use constant ABSTRACT_SCHEMA => {
         REFERENCES => {TABLE => 'products', COLUMN => 'id', DELETE => 'CASCADE'}
       },
       component_id => {
-        TYPE       => 'INT2',
+        TYPE       => 'INT3',
         REFERENCES => {TABLE => 'components', COLUMN => 'id', DELETE => 'CASCADE'}
       },
     ],
@@ -1162,7 +1162,7 @@ use constant ABSTRACT_SCHEMA => {
         REFERENCES => {TABLE => 'profiles', COLUMN => 'userid', DELETE => 'CASCADE'}
       },
       component_id => {
-        TYPE       => 'INT2',
+        TYPE       => 'INT3',
         NOTNULL    => 1,
         REFERENCES => {TABLE => 'components', COLUMN => 'id', DELETE => 'CASCADE'}
       },
@@ -1447,7 +1447,7 @@ use constant ABSTRACT_SCHEMA => {
 
   components => {
     FIELDS => [
-      id         => {TYPE => 'SMALLSERIAL', NOTNULL => 1, PRIMARYKEY => 1},
+      id         => {TYPE => 'MEDIUMSERIAL', NOTNULL => 1, PRIMARYKEY => 1},
       name       => {TYPE => 'varchar(64)', NOTNULL => 1},
       product_id => {
         TYPE       => 'INT2',

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -821,6 +821,15 @@ sub update_table_definitions {
     {table => 'user_request_log', column => 'attach_id', definition => {TYPE => 'INT5', NOTNULL => 0}},
   ]);
 
+  # Bug 903895 - sgreen@redhat.com
+  $dbh->bz_fk_safe_alter_columns([
+    {table => 'flaginclusions', column => 'component_id', definition => {TYPE => 'INT3'}},
+    {table => 'flagexclusions', column => 'component_id', definition => {TYPE => 'INT3'}},
+    {table => 'bugs',           column => 'component_id', definition => {TYPE => 'INT3', NOTNULL => 1}},
+    {table => 'component_cc',    column => 'component_id', definition => {TYPE => 'INT3', NOTNULL => 1}},
+    {table => 'components',      column => 'id',           definition => {TYPE => 'MEDIUMSERIAL', NOTNULL => 1, PRIMARYKEY => 1}},
+  ]);
+
   _populate_attachment_storage_class();
 
 
@@ -1592,6 +1601,9 @@ sub _use_ids_for_products_and_components {
 
     print "Updating the database to use component IDs.\n";
 
+    # NOTE: These columns are now MEDIUMSERIAL/INT3 in the current schema, but
+    # historically were originally created as SMALLSERIAL/INT2. The upgrade steps
+    # are done in order; they will be converted to the correct current type later.
     $dbh->bz_add_column("components", "id",
       {TYPE => 'SMALLSERIAL', NOTNULL => 1, PRIMARYKEY => 1});
     $dbh->bz_add_column("bugs", "component_id", {TYPE => 'INT2', NOTNULL => 1}, 0);

--- a/extensions/BugmailFilter/Extension.pm
+++ b/extensions/BugmailFilter/Extension.pm
@@ -421,7 +421,6 @@ sub reorg_move_component {
 
 sub db_schema_abstract_schema {
   my ($self, $args) = @_;
-  my $component_id_type = _component_id_type_from_schema($args->{schema});
 
   $args->{schema}->{bugmail_filters} = {
     FIELDS => [
@@ -443,7 +442,7 @@ sub db_schema_abstract_schema {
         REFERENCES => {TABLE => 'products', COLUMN => 'id', DELETE => 'CASCADE'},
       },
       component_id => {
-        TYPE       => $component_id_type,
+        TYPE       => 'INT3',
         NOTNULL    => 0,
         REFERENCES => {TABLE => 'components', COLUMN => 'id', DELETE => 'CASCADE'},
       },
@@ -473,36 +472,12 @@ sub install_update_db {
   $dbh->bz_add_column('bugmail_filters', 'changer_id',
     {TYPE => 'INT3', NOTNULL => 0,});
 
-  my $component_id_type = _component_id_type_from_db($dbh);
-
   my @fixes = (
     {table => 'bugmail_filters', column => 'product_id', definition => {TYPE => 'INT2', NOTNULL => 0}},
-    {table => 'bugmail_filters', column => 'component_id', definition => {TYPE => $component_id_type, NOTNULL => 0}},
+    {table => 'bugmail_filters', column => 'component_id', definition => {TYPE => 'INT3', NOTNULL => 0}},
   );
 
   $dbh->bz_fk_safe_alter_columns(\@fixes);
-}
-
-sub _component_id_type_from_schema {
-  my ($schema) = @_;
-
-  my $component_id_type = 'INT2';
-  my $len               = scalar @{$schema->{components}->{FIELDS}};
-  for (my $i = 0; $i < $len - 1; $i += 2) {
-    next if $schema->{components}->{FIELDS}->[$i] ne 'id';
-    $component_id_type = 'INT3'
-      if $schema->{components}->{FIELDS}->[$i + 1]->{TYPE} eq 'MEDIUMSERIAL';
-    last;
-  }
-
-  return $component_id_type;
-}
-
-sub _component_id_type_from_db {
-  my ($dbh) = @_;
-
-  my $component_id = $dbh->bz_column_info('components', 'id');
-  return $component_id->{TYPE} eq 'MEDIUMSERIAL' ? 'INT3' : 'INT2';
 }
 
 sub db_sanitize {

--- a/extensions/BugmailFilter/Extension.pm
+++ b/extensions/BugmailFilter/Extension.pm
@@ -421,6 +421,8 @@ sub reorg_move_component {
 
 sub db_schema_abstract_schema {
   my ($self, $args) = @_;
+  my $component_id_type = _component_id_type_from_schema($args->{schema});
+
   $args->{schema}->{bugmail_filters} = {
     FIELDS => [
       id      => {TYPE => 'INTSERIAL', NOTNULL => 1, PRIMARYKEY => 1,},
@@ -441,7 +443,7 @@ sub db_schema_abstract_schema {
         REFERENCES => {TABLE => 'products', COLUMN => 'id', DELETE => 'CASCADE'},
       },
       component_id => {
-        TYPE       => 'INT2',
+        TYPE       => $component_id_type,
         NOTNULL    => 0,
         REFERENCES => {TABLE => 'components', COLUMN => 'id', DELETE => 'CASCADE'},
       },
@@ -467,8 +469,40 @@ sub db_schema_abstract_schema {
 }
 
 sub install_update_db {
-  Bugzilla->dbh->bz_add_column('bugmail_filters', 'changer_id',
+  my $dbh = Bugzilla->dbh;
+  $dbh->bz_add_column('bugmail_filters', 'changer_id',
     {TYPE => 'INT3', NOTNULL => 0,});
+
+  my $component_id_type = _component_id_type_from_db($dbh);
+
+  my @fixes = (
+    {table => 'bugmail_filters', column => 'product_id', definition => {TYPE => 'INT2', NOTNULL => 0}},
+    {table => 'bugmail_filters', column => 'component_id', definition => {TYPE => $component_id_type, NOTNULL => 0}},
+  );
+
+  $dbh->bz_fk_safe_alter_columns(\@fixes);
+}
+
+sub _component_id_type_from_schema {
+  my ($schema) = @_;
+
+  my $component_id_type = 'INT2';
+  my $len               = scalar @{$schema->{components}->{FIELDS}};
+  for (my $i = 0; $i < $len - 1; $i += 2) {
+    next if $schema->{components}->{FIELDS}->[$i] ne 'id';
+    $component_id_type = 'INT3'
+      if $schema->{components}->{FIELDS}->[$i + 1]->{TYPE} eq 'MEDIUMSERIAL';
+    last;
+  }
+
+  return $component_id_type;
+}
+
+sub _component_id_type_from_db {
+  my ($dbh) = @_;
+
+  my $component_id = $dbh->bz_column_info('components', 'id');
+  return $component_id->{TYPE} eq 'MEDIUMSERIAL' ? 'INT3' : 'INT2';
 }
 
 sub db_sanitize {

--- a/extensions/BugmailFilter/Extension.pm
+++ b/extensions/BugmailFilter/Extension.pm
@@ -472,12 +472,10 @@ sub install_update_db {
   $dbh->bz_add_column('bugmail_filters', 'changer_id',
     {TYPE => 'INT3', NOTNULL => 0,});
 
-  my @fixes = (
+  $dbh->bz_fk_safe_alter_columns([
     {table => 'bugmail_filters', column => 'product_id', definition => {TYPE => 'INT2', NOTNULL => 0}},
     {table => 'bugmail_filters', column => 'component_id', definition => {TYPE => 'INT3', NOTNULL => 0}},
-  );
-
-  $dbh->bz_fk_safe_alter_columns(\@fixes);
+  ]);
 }
 
 sub db_sanitize {

--- a/extensions/ComponentWatching/Extension.pm
+++ b/extensions/ComponentWatching/Extension.pm
@@ -83,6 +83,11 @@ sub install_update_db {
   );
   $dbh->bz_add_column('component_watch', 'component_prefix',
     {TYPE => 'VARCHAR(64)', NOTNULL => 0,});
+
+  # Bug 2052640 - justdave@bugzilla.org
+  $dbh->bz_fk_safe_alter_columns([
+    {table => 'component_watch', column => 'component_id', definition => {TYPE => 'INT3', NOTNULL => 0}},
+  ]);
 }
 
 #

--- a/extensions/Review/Extension.pm
+++ b/extensions/Review/Extension.pm
@@ -837,7 +837,7 @@ sub db_schema_abstract_schema {
       },
       display_name => {TYPE => 'VARCHAR(64)',},
       component_id => {
-        TYPE       => 'INT2',
+        TYPE       => 'INT3',
         NOTNULL    => 1,
         REFERENCES => {TABLE => 'components', COLUMN => 'id', DELETE => 'CASCADE',}
       },
@@ -963,6 +963,12 @@ sub install_update_db {
     $def->{TYPE} = 'INT3';
     $dbh->bz_alter_column('flag_state_activity', 'type_id', $def);
   }
+
+  # Bug 2052640 - justdave@bugzilla.org
+  $dbh->bz_fk_safe_alter_columns([
+    {table => 'component_reviewers', column => 'component_id', definition => {TYPE => 'INT3', NOTNULL => 1}},
+  ]);
+
 }
 
 sub install_filesystem {

--- a/extensions/TrackingFlags/Extension.pm
+++ b/extensions/TrackingFlags/Extension.pm
@@ -261,7 +261,7 @@ sub db_schema_abstract_schema {
         REFERENCES => {TABLE => 'products', COLUMN => 'id', DELETE => 'CASCADE',},
       },
       component_id => {
-        TYPE       => 'INT2',
+        TYPE       => 'INT3',
         NOTNULL    => 0,
         REFERENCES => {TABLE => 'components', COLUMN => 'id', DELETE => 'CASCADE',},
       },
@@ -289,6 +289,11 @@ sub install_update_db {
   $dbh->bz_add_column('tracking_flags_values', 'comment',
     {TYPE => 'TEXT', NOTNULL => 0,},
   );
+
+  # Bug 2052640 - justdave@bugzilla.org
+  $dbh->bz_fk_safe_alter_columns([
+    {table => 'tracking_flags_visibility', column => 'component_id', definition => {TYPE => 'INT3', NOTNULL => 0}},
+  ]);
 }
 
 sub install_filesystem {

--- a/extensions/Webhooks/Extension.pm
+++ b/extensions/Webhooks/Extension.pm
@@ -48,7 +48,7 @@ sub db_schema_abstract_schema {
         REFERENCES => {TABLE => 'products', COLUMN => 'id', DELETE => 'CASCADE',}
       },
       component_id => {
-        TYPE       => 'INT2',
+        TYPE       => 'INT3',
         NOTNULL    => 0,
         REFERENCES => {TABLE => 'components', COLUMN => 'id', DELETE => 'CASCADE',}
       }
@@ -63,6 +63,12 @@ sub db_sanitize {
   my $dbh = Bugzilla->dbh;
   print "Deleting webhooks...\n";
   $dbh->do("DELETE FROM webhooks");
+}
+
+sub install_update_db {
+  Bugzilla->dbh->bz_fk_safe_alter_columns([
+    {table => 'webhooks', column => 'component_id', definition => {TYPE => 'INT3', NOTNULL => 0}},
+  ]);
 }
 
 #

--- a/extensions/Webhooks/Extension.pm
+++ b/extensions/Webhooks/Extension.pm
@@ -66,6 +66,7 @@ sub db_sanitize {
 }
 
 sub install_update_db {
+  # Bug 2052640 - justdave@bugzilla.org
   Bugzilla->dbh->bz_fk_safe_alter_columns([
     {table => 'webhooks', column => 'component_id', definition => {TYPE => 'INT3', NOTNULL => 0}},
   ]);


### PR DESCRIPTION
#### Details
Mainline Bugzilla converted the components.id field from a SMALLSERIAL to a MEDIUMSERIAL about 12 years ago, but that never landed on BMO/harmony. The lack of it breaks upgrading to Harmony from 5.x releases. So this ports the original patch into Harmony.

#### Additional info
* [bug#2052640](https://bugzilla.mozilla.org/show_bug.cgi?id=2052640)

#### Test Plan
1. `docker compose up`
2. Used the Files tab in Docker Desktop to drop a mysqldump of a Bugzilla 5.0.4 install into /root on the database image
3. Used the Exec tab in Docker Desktop to restore that dump into the database
4. `docker compose down`
5. `docker compose up` and watch the output to confirm that checksetup.pl no longer shows the foreign key error and makes it past where that was previously happening.
