### PR TITLE
Bug 2052749: Example extension causes the t/markdown test to fail

### DIFF
--- a/t/markdown.t
+++ b/t/markdown.t
@@ -84,6 +84,15 @@ my $angle_link_dom = Mojo::DOM->new($angle_link);
 my $ahref = $angle_link_dom->at('a[href]');
 is($ahref->attr('href'), 'https://searchfox.org/mozilla-central/rev/76fe4bb385348d3f45bbebcf69ba8c7283dfcec7/mobile/android/base/java/org/mozilla/gecko/toolbar/SecurityModeUtil.java#101', 'angle links are parsed properly');
 
-is($parser->render_html('<foo>'), "<p>&lt;foo&gt;</p>\n", "literal tags work");
+# Test that literal tags are not parsed as HTML, but are instead escaped.
+# Need to use a tag that is not likely to get used in a real use case,
+# because the bug_format_comment extension hook is allowed to arbitrarily
+# modify the comment text, and we don't want to accidentally break a real
+# use case where the tag contents might get modified and break our test.
+is(
+  $parser->render_html('<markdownliteraltesttoken>'),
+  "<p>&lt;markdownliteraltesttoken&gt;</p>\n",
+  'literal tags work'
+);
 
 done_testing;


### PR DESCRIPTION
#### Details
The test itself is probably too loose - it's passing a test string that would commonly be used elsewhere for something else (like in the Example extension, which also uses 'foo' in a replacement that trips the test). The most robust fix for this is to make the test pass a tag that won't likely ever get used in a production use case.

#### Additional info
* [bug#2052749](https://bugzilla.mozilla.org/show_bug.cgi?id=2052749)

#### Test Plan
1. Have an unpatched Bugzilla
2. `rm extensions/Example/disabled`
3. `sh docker/run-tests-in-docker.sh` - pick option 6
4. Observe the test failure.
5. check out this PR branch.
6. `rm extensions/Example/disabled`
7. `sh docker/run-tests-in-docker.sh` - pick option 6
8. Observe the test no longer fails. (a different test might fail, but that's Another Bug™)