### PR TITLE
Bug 2052751: run tests from docker FASTER

### DIFF
--- a/docker/images/Dockerfile.perl-testsuite
+++ b/docker/images/Dockerfile.perl-testsuite
@@ -47,6 +47,6 @@ COPY . /app/
 # Run checksetup
 RUN perl checksetup.pl --no-database --default-localconfig --no-templates
 
-# Set the default command to run tests
-ENTRYPOINT ["prove", "-Ilocal/lib/perl5", "t"]
-CMD []
+# Set a default test target but allow callers to override/append prove args.
+ENTRYPOINT ["prove", "-Ilocal/lib/perl5"]
+CMD ["t"]

--- a/docker/images/Dockerfile.perl-testsuite
+++ b/docker/images/Dockerfile.perl-testsuite
@@ -47,6 +47,12 @@ COPY . /app/
 # Run checksetup
 RUN perl checksetup.pl --no-database --default-localconfig --no-templates
 
-# Set a default test target but allow callers to override/append prove args.
-ENTRYPOINT ["prove", "-Ilocal/lib/perl5"]
+# Support both prove (default) and perl commands via a dispatcher script.
+# the perl option is so you can do `perl -c` on a file in the container
+# to make sure it compiles when you don't have dependencies on the host
+# machine.
+COPY docker/images/perl-testsuite-entrypoint.sh /usr/local/bin/perl-testsuite-entrypoint
+RUN chmod +x /usr/local/bin/perl-testsuite-entrypoint
+
+ENTRYPOINT ["/usr/local/bin/perl-testsuite-entrypoint"]
 CMD ["t"]

--- a/docker/images/Dockerfile.perl-testsuite
+++ b/docker/images/Dockerfile.perl-testsuite
@@ -29,14 +29,20 @@ RUN apt-get update && apt-get -y dist-upgrade && \
     unzip wget && \
     rm -rf /var/lib/apt/lists/*
 
-# Copy the source code
-COPY . /app/
+# Copy just enough to get the list of dependencies
+COPY Bugzilla.pm Makefile.PL gen-cpanfile.pl /app/
 
 # Run Makefile.PL and install dependencies
 RUN perl Makefile.PL && \
     cpanm --notest --quiet --local-lib="/app/local" Module::CPANfile && \
     make cpanfile GEN_CPANFILE_ARGS='-A -U oracle -U mariadb -U pg -U mysql' && \
     cpanm --notest --quiet --local-lib="/app/local" -f --installdeps .
+
+# Now copy all of the source. Splitting it from the dependency-related files
+# above allows Docker to cache the dependency install step unless the
+# dependencies change, saving a *lot* of build time when you just want to run
+# tests
+COPY . /app/
 
 # Run checksetup
 RUN perl checksetup.pl --no-database --default-localconfig --no-templates

--- a/docker/images/perl-testsuite-entrypoint.sh
+++ b/docker/images/perl-testsuite-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -eq 0 ]; then
+    exec prove -Ilocal/lib/perl5 t
+fi
+
+case "$1" in
+    prove)
+        shift
+        exec prove -Ilocal/lib/perl5 "$@"
+        ;;
+    perl)
+        shift
+        exec perl -I/app -I/app/local/lib/perl5 "$@"
+        ;;
+    *)
+        exec prove -Ilocal/lib/perl5 "$@"
+        ;;
+esac

--- a/docker/run-tests-in-docker.sh
+++ b/docker/run-tests-in-docker.sh
@@ -16,6 +16,8 @@ export CIRCLE_BUILD_URL=""
 
 TEST_NAME="test_bmo"
 DOCKER_COMPOSE_FILE=docker-compose.test-mysql.yml
+DEFAULT_TEST_ARGS=(-q -f t/bmo/*.t)
+SUITE_ARGS=()
 if [ "$#" -eq 0 ]; then
     echo "Available test options:"
     echo "  1) sanity   - Run sanity tests"
@@ -36,28 +38,41 @@ if [ "$#" -eq 0 ]; then
         *) echo "Invalid choice. Using default (mysql)"; set -- "mysql" ;;
     esac
 fi
-if [ "$1" == "sanity" ]; then
+SUITE="$1"
+shift
+SUITE_ARGS=("$@")
+
+if [ "$SUITE" == "sanity" ]; then
     DOCKER_COMPOSE_FILE=docker-compose.test-mysql.yml
     TEST_NAME="test_sanity"
-elif [ "$1" == "mysql" ]; then
+elif [ "$SUITE" == "mysql" ]; then
     DOCKER_COMPOSE_FILE=docker-compose.test-mysql.yml
-elif [ "$1" == "pg" ]; then
+elif [ "$SUITE" == "pg" ]; then
     DOCKER_COMPOSE_FILE=docker-compose.test-pg.yml
-elif [ "$1" == "sqlite" ]; then
+elif [ "$SUITE" == "sqlite" ]; then
     DOCKER_COMPOSE_FILE=docker-compose.test-sqlite.yml
-elif [ "$1" == "mariadb" ]; then
+elif [ "$SUITE" == "mariadb" ]; then
     DOCKER_COMPOSE_FILE=docker-compose.test-mariadb.yml
-elif [ "$1" == "release" ]; then
+elif [ "$SUITE" == "release" ]; then
     DOCKER_FILE=docker/images/Dockerfile.perl-testsuite
     if $DOCKER build -t bugzilla-release-test -f "$DOCKER_FILE" .; then
-        $DOCKER run --rm bugzilla-release-test
+        $DOCKER run --rm bugzilla-release-test "${SUITE_ARGS[@]}"
     else
         echo "docker build failed."
     fi
     exit $?
+else
+    echo "Unknown test suite: $SUITE"
+    echo "Usage: $0 [sanity|mysql|pg|sqlite|mariadb|release] [suite args...]"
+    exit 1
 fi
+
+if [ "${#SUITE_ARGS[@]}" -eq 0 ]; then
+    SUITE_ARGS=("${DEFAULT_TEST_ARGS[@]}")
+fi
+
 if $DOCKER compose -f "$DOCKER_COMPOSE_FILE" build; then
-    if $DOCKER compose -f "$DOCKER_COMPOSE_FILE" run --rm --name bugzilla6.test bugzilla6.test "$TEST_NAME" -q -f t/bmo/*.t; then
+    if $DOCKER compose -f "$DOCKER_COMPOSE_FILE" run --rm --name bugzilla6.test bugzilla6.test "$TEST_NAME" "${SUITE_ARGS[@]}"; then
         $DOCKER compose -f "$DOCKER_COMPOSE_FILE" down
     else
         echo "docker compose run failed."


### PR DESCRIPTION
#### Details
Only copy enough to run the dependency install before installing dependencies, so that you don't have to reinstall dependencies any time you touch anything in the repository.

#### Additional info
* [bug#2052751](https://bugzilla.mozilla.org/show_bug.cgi?id=2052751)

#### Test Plan
1. `sh docker/run-tests-in-docker.sh` - pick option 6
2. make a material change to any file other than `Bugzilla.pm`, `Makefile.PL`, or `gen-cpanfile.sh`
3. Do step 1 again, notice it starts running tests within 10 seconds. instead of waiting 5 to 10 minutes for dependency install.