### PR TITLE
Bug 2054397: Test Perl code for vendor-specific SQL

### DIFF
--- a/Bugzilla/DB.pm
+++ b/Bugzilla/DB.pm
@@ -411,7 +411,7 @@ EOT
 
 # List of abstract methods we are checking the derived class implements
 our @_abstract_methods = qw(new sql_regexp sql_not_regexp sql_limit sql_to_days
-  sql_date_format sql_date_math bz_explain
+  sql_date_format sql_date_math sql_date_to_epoch bz_explain
   sql_group_concat);
 
 # This overridden import method will check implementation of inherited classes
@@ -2189,6 +2189,31 @@ C<string> the units the interval is in (e.g. 'MINUTE')
 =item B<Returns>
 
 Formatted SQL for adding or subtracting a date and some amount of time (scalar)
+
+=back
+
+=item C<sql_date_to_epoch>
+
+=over
+
+=item B<Description>
+
+Outputs SQL syntax for converting a date/time expression to Unix epoch
+seconds.
+
+Abstract method, should be overridden by database specific code.
+
+=item B<Params>
+
+=over
+
+=item C<$date> - date or name of date type column (scalar)
+
+=back
+
+=item B<Returns>
+
+Formatted SQL for Unix epoch seconds (scalar)
 
 =back
 

--- a/Bugzilla/DB/MariaDB.pm
+++ b/Bugzilla/DB/MariaDB.pm
@@ -228,6 +228,12 @@ sub sql_date_math {
   return "$date $operator INTERVAL $interval $units";
 }
 
+sub sql_date_to_epoch {
+  my ($self, $date) = @_;
+
+  return "UNIX_TIMESTAMP($date)";
+}
+
 sub sql_iposition {
   my ($self, $fragment, $text) = @_;
   return "INSTR($text, $fragment)";

--- a/Bugzilla/DB/Mysql.pm
+++ b/Bugzilla/DB/Mysql.pm
@@ -229,6 +229,12 @@ sub sql_date_math {
   return "$date $operator INTERVAL $interval $units";
 }
 
+sub sql_date_to_epoch {
+  my ($self, $date) = @_;
+
+  return "UNIX_TIMESTAMP($date)";
+}
+
 sub sql_iposition {
   my ($self, $fragment, $text) = @_;
   return "INSTR($text, $fragment)";

--- a/Bugzilla/DB/Oracle.pm
+++ b/Bugzilla/DB/Oracle.pm
@@ -203,6 +203,12 @@ sub sql_date_math {
   return "$date $operator $time_sql";
 }
 
+sub sql_date_to_epoch {
+  my ($self, $date) = @_;
+
+  return "TRUNC(($date - DATE '1970-01-01') * 86400)";
+}
+
 sub sql_position {
   my ($self, $fragment, $text) = @_;
   return "INSTR($text, $fragment)";

--- a/Bugzilla/DB/Pg.pm
+++ b/Bugzilla/DB/Pg.pm
@@ -155,6 +155,12 @@ sub sql_date_math {
   return "$date $operator $interval * INTERVAL '1 $units'";
 }
 
+sub sql_date_to_epoch {
+  my ($self, $date) = @_;
+
+  return "CAST(EXTRACT(EPOCH FROM $date) AS BIGINT)";
+}
+
 sub sql_string_concat {
   my ($self, @params) = @_;
 

--- a/Bugzilla/DB/Sqlite.pm
+++ b/Bugzilla/DB/Sqlite.pm
@@ -235,6 +235,12 @@ sub sql_date_math {
   return "DATETIME($date, '$operator' || $interval || ' $units')";
 }
 
+sub sql_date_to_epoch {
+  my ($self, $date) = @_;
+
+  return "CAST(STRFTIME('%s', $date) AS INTEGER)";
+}
+
 ###############
 # bz_ methods #
 ###############

--- a/Bugzilla/Report/SecurityRisk.pm
+++ b/Bugzilla/Report/SecurityRisk.pm
@@ -293,15 +293,15 @@ sub _build_events {
   . $dbh->sql_string_concat('removed') . qq{ AS removed,
       }
   . $dbh->sql_string_concat('added') . qq{ AS added
-    FROM
-      bugs_activity
-      JOIN fielddefs AS field ON fieldid = field.id
-      JOIN bugs AS bug USING (bug_id)
-    WHERE
-      bug_id IN ($bug_ids)
-      AND field.name IN ('keywords' , 'bug_status')
-      AND bug_when >= '$start_date'
-    GROUP BY bug_id , bug_when , field.name
+        FROM
+            bugs_activity
+            JOIN fielddefs AS field ON fieldid = field.id
+            JOIN bugs AS bug USING (bug_id)
+        WHERE
+            bug_id IN ($bug_ids)
+            AND field.name IN ('keywords' , 'bug_status')
+            AND bug_when >= '$start_date'
+        GROUP BY bug_id , bug_when , field.name
   };
   # Don't use selectall_hashref as it only gets the latest event each bug.
   my $result = $dbh->selectall_arrayref($query);

--- a/Bugzilla/Report/SecurityRisk.pm
+++ b/Bugzilla/Report/SecurityRisk.pm
@@ -280,6 +280,7 @@ sub _build_initial_bugs {
 
 sub _build_events {
   my ($self) = @_;
+  my $dbh = Bugzilla->dbh;
   return [] if !(@{$self->initial_bug_ids});
   my $bug_ids    = join ', ', @{$self->initial_bug_ids};
   my $start_date = $self->start_date->strftime('%Y-%m-%d %H:%M:%S');
@@ -288,20 +289,22 @@ sub _build_events {
             bug_id,
             bug_when,
             field.name AS field_name,
-            CONCAT(removed) AS removed,
-            CONCAT(added) AS added
-        FROM
-            bugs_activity
-            JOIN fielddefs AS field ON fieldid = field.id
-            JOIN bugs AS bug USING (bug_id)
-        WHERE
-            bug_id IN ($bug_ids)
-            AND field.name IN ('keywords' , 'bug_status')
-            AND bug_when >= '$start_date'
-        GROUP BY bug_id , bug_when , field.name
-    };
+      }
+  . $dbh->sql_string_concat('removed') . qq{ AS removed,
+      }
+  . $dbh->sql_string_concat('added') . qq{ AS added
+    FROM
+      bugs_activity
+      JOIN fielddefs AS field ON fieldid = field.id
+      JOIN bugs AS bug USING (bug_id)
+    WHERE
+      bug_id IN ($bug_ids)
+      AND field.name IN ('keywords' , 'bug_status')
+      AND bug_when >= '$start_date'
+    GROUP BY bug_id , bug_when , field.name
+  };
   # Don't use selectall_hashref as it only gets the latest event each bug.
-  my $result = Bugzilla->dbh->selectall_arrayref($query);
+  my $result = $dbh->selectall_arrayref($query);
   my $type   = ArrayRef [Tuple [Int, Str, Str, Str, Str]];
   $type->assert_valid($result);
 

--- a/Bugzilla/Report/SecurityRisk.pm
+++ b/Bugzilla/Report/SecurityRisk.pm
@@ -290,9 +290,9 @@ sub _build_events {
             bug_when,
             field.name AS field_name,
       }
-  . $dbh->sql_string_concat('removed') . qq{ AS removed,
+    . $dbh->sql_string_concat('removed') . qq{ AS removed,
       }
-  . $dbh->sql_string_concat('added') . qq{ AS added
+    . $dbh->sql_string_concat('added') . qq{ AS added
         FROM
             bugs_activity
             JOIN fielddefs AS field ON fieldid = field.id

--- a/extensions/BMO/lib/Reports/Triage.pm
+++ b/extensions/BMO/lib/Reports/Triage.pm
@@ -314,7 +314,9 @@ sub owners {
                            LEFT JOIN attachments AS attachments_1 ON bugs_1.bug_id = attachments_1.bug_id
                            LEFT JOIN flags AS flags_1 ON bugs_1.bug_id = flags_1.bug_id AND (flags_1.attach_id = attachments_1.attach_id OR flags_1.attach_id IS NULL)
                            LEFT JOIN flagtypes AS flagtypes_1 ON flags_1.type_id = flagtypes_1.id
-                    WHERE  bugs_1.bug_id = bugs.bug_id AND CONCAT(flagtypes_1.name, flags_1.status) = 'needinfo?')))
+                        WHERE  bugs_1.bug_id = bugs.bug_id AND "
+                . $dbh->sql_string_concat('flagtypes_1.name', 'flags_1.status')
+                . " = 'needinfo?')))
                 AND bugs.component_id = ?
        GROUP BY bugs.bug_type");
 

--- a/extensions/BMO/lib/Reports/UserActivity.pm
+++ b/extensions/BMO/lib/Reports/UserActivity.pm
@@ -182,7 +182,9 @@ sub report {
                    'longdesc' AS name,
                    longdescs.bug_id,
                    NULL AS attach_id,
-                   DATE_FORMAT(longdescs.bug_when, '%Y-%m-%d %H:%i:%s') AS ts,
+                   "
+      . $dbh->sql_date_format('longdescs.bug_when', '%Y-%m-%d %H:%i:%s')
+      . " AS ts,
                    '' AS removed,
                    '' AS added,
                    profiles.login_name,

--- a/extensions/BugModal/lib/ActivityStream.pm
+++ b/extensions/BugModal/lib/ActivityStream.pm
@@ -358,7 +358,8 @@ sub _add_duplicates_to_stream {
 
   my $sth = $dbh->prepare("
         SELECT longdescs.who,
-        " . $dbh->sql_date_format('bug_when') . ",
+               " . $dbh->sql_date_to_epoch('bug_when') . ",
+               " . $dbh->sql_date_format('bug_when') . ",
                type,
                extra_data
           FROM longdescs
@@ -368,8 +369,7 @@ sub _add_duplicates_to_stream {
     ");
   $sth->execute($bug->id, CMT_HAS_DUPE, CMT_DUPE_OF);
 
-  while (my ($who, $when, $type, $dupe_id) = $sth->fetchrow_array) {
-    my $time = date_str_to_time($when);
+  while (my ($who, $time, $when, $type, $dupe_id) = $sth->fetchrow_array) {
     _add_activity_to_stream(
       $stream, $time, $who,
       {

--- a/extensions/BugModal/lib/ActivityStream.pm
+++ b/extensions/BugModal/lib/ActivityStream.pm
@@ -358,7 +358,7 @@ sub _add_duplicates_to_stream {
 
   my $sth = $dbh->prepare("
         SELECT longdescs.who,
-               UNIX_TIMESTAMP(bug_when), " . $dbh->sql_date_format('bug_when') . ",
+        " . $dbh->sql_date_format('bug_when') . ",
                type,
                extra_data
           FROM longdescs
@@ -368,7 +368,8 @@ sub _add_duplicates_to_stream {
     ");
   $sth->execute($bug->id, CMT_HAS_DUPE, CMT_DUPE_OF);
 
-  while (my ($who, $time, $when, $type, $dupe_id) = $sth->fetchrow_array) {
+  while (my ($who, $when, $type, $dupe_id) = $sth->fetchrow_array) {
+    my $time = date_str_to_time($when);
     _add_activity_to_stream(
       $stream, $time, $who,
       {

--- a/extensions/ProdCompSearch/lib/WebService.pm
+++ b/extensions/ProdCompSearch/lib/WebService.pm
@@ -207,7 +207,7 @@ sub _build_like_order {
   my @terms;
   foreach my $word (split(/[\s,]+/, $query)) {
     push @terms,
-      "CONCAT(products.name, components.name) LIKE "
+      $dbh->sql_string_concat('products.name', 'components.name') . " LIKE "
       . $dbh->quote('%' . $word . '%')
       if $word ne '';
   }

--- a/extensions/UserProfile/lib/Util.pm
+++ b/extensions/UserProfile/lib/Util.pm
@@ -247,7 +247,7 @@ sub _activity_by_status {
            AND fieldid = ?
      GROUP BY added
      UNION ALL
-    SELECT CONCAT('RESOLVED/', added) AS status, COUNT(*) AS count
+    SELECT @{[$dbh->sql_string_concat($dbh->quote('RESOLVED/'), 'added')]} AS status, COUNT(*) AS count
       FROM bugs_activity
      WHERE who = ?
            AND fieldid = ?

--- a/scripts/nagios_blocker_checker.pl
+++ b/scripts/nagios_blocker_checker.pl
@@ -183,8 +183,8 @@ try {
     $where .= " AND bug_severity IN ($severities)";
   }
 
-  my $sql = <<"EOF";
-        SELECT bug_id, bug_severity, UNIX_TIMESTAMP(bugs.creation_ts) AS ts
+    my $sql = <<"EOF";
+      SELECT bug_id, bug_severity, @{[$dbh->sql_date_to_epoch('bugs.creation_ts')]} AS ts
           FROM bugs
          WHERE $where
                AND COALESCE(resolution, '') = ''

--- a/scripts/nagios_blocker_checker.pl
+++ b/scripts/nagios_blocker_checker.pl
@@ -183,7 +183,7 @@ try {
     $where .= " AND bug_severity IN ($severities)";
   }
 
-    my $sql = <<"EOF";
+  my $sql = <<"EOF";
       SELECT bug_id, bug_severity, @{[$dbh->sql_date_to_epoch('bugs.creation_ts')]} AS ts
           FROM bugs
          WHERE $where

--- a/t/013db_portability.t
+++ b/t/013db_portability.t
@@ -35,8 +35,8 @@ push @files, grep { !$seen_file{$_}++ } @script_files;
 my @rules = (
   {
     token => qr/\bUNIX_TIMESTAMP\s*\(/,
-    helper => 'sql_date_format',
-    message => 'use $dbh->sql_date_format(...) instead of UNIX_TIMESTAMP()',
+    helper => 'sql_date_to_epoch',
+    message => 'use $dbh->sql_date_to_epoch(...) instead of UNIX_TIMESTAMP()',
   },
   {
     token => qr/\bDATE_FORMAT\s*\(/,

--- a/t/013db_portability.t
+++ b/t/013db_portability.t
@@ -34,27 +34,27 @@ push @files, grep { !$seen_file{$_}++ } @script_files;
 
 my @rules = (
   {
-    token => qr/\bUNIX_TIMESTAMP\s*\(/,
+    token => qr/\bUNIX_TIMESTAMP\s*\(/i,
     helper => 'sql_date_to_epoch',
     message => 'use $dbh->sql_date_to_epoch(...) instead of UNIX_TIMESTAMP()',
   },
   {
-    token => qr/\bDATE_FORMAT\s*\(/,
+    token => qr/\bDATE_FORMAT\s*\(/i,
     helper => 'sql_date_format',
     message => 'use $dbh->sql_date_format(...) instead of DATE_FORMAT()',
   },
   {
-    token => qr/\bCONCAT\s*\(/,
+    token => qr/\bCONCAT\s*\(/i,
     helper => 'sql_string_concat',
     message => 'use $dbh->sql_string_concat(...) instead of CONCAT()',
   },
   {
-    token => qr/\b(?:POSITION|INSTR|LOCATE)\s*\(/,
+    token => qr/\b(?:POSITION|INSTR|LOCATE)\s*\(/i,
     helper => 'sql_position/sql_iposition',
     message => 'use $dbh->sql_position(...) or $dbh->sql_iposition(...) instead',
   },
   {
-    token => qr/\bGROUP_CONCAT\s*\(/,
+    token => qr/\bGROUP_CONCAT\s*\(/i,
     helper => 'sql_group_concat',
     message => 'use $dbh->sql_group_concat(...) instead of GROUP_CONCAT()',
   },

--- a/t/013db_portability.t
+++ b/t/013db_portability.t
@@ -12,12 +12,25 @@ use warnings;
 use lib qw(. lib local/lib/perl5 t);
 
 use Support::Files;
+use File::Find;
 
 use Test::More;
 
 my %seen_file;
 my @files = grep { $_ ne 't/013db_portability.t' && !$seen_file{$_}++ }
   (@Support::Files::testitems, @Support::Files::test_files);
+
+my @script_files;
+find(
+  sub {
+    return if -d;
+    return unless /\.pl$/;
+    push @script_files, $File::Find::name;
+  },
+  'scripts'
+);
+
+push @files, grep { !$seen_file{$_}++ } @script_files;
 
 my @rules = (
   {

--- a/t/013db_portability.t
+++ b/t/013db_portability.t
@@ -1,0 +1,88 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+use 5.14.0;
+use strict;
+use warnings;
+
+use lib qw(. lib local/lib/perl5 t);
+
+use Support::Files;
+
+use Test::More;
+
+my %seen_file;
+my @files = grep { $_ ne 't/013db_portability.t' && !$seen_file{$_}++ }
+  (@Support::Files::testitems, @Support::Files::test_files);
+
+my @rules = (
+  {
+    token => qr/\bUNIX_TIMESTAMP\s*\(/,
+    helper => 'sql_date_format',
+    message => 'use $dbh->sql_date_format(...) instead of UNIX_TIMESTAMP()',
+  },
+  {
+    token => qr/\bDATE_FORMAT\s*\(/,
+    helper => 'sql_date_format',
+    message => 'use $dbh->sql_date_format(...) instead of DATE_FORMAT()',
+  },
+  {
+    token => qr/\bCONCAT\s*\(/,
+    helper => 'sql_string_concat',
+    message => 'use $dbh->sql_string_concat(...) instead of CONCAT()',
+  },
+  {
+    token => qr/\b(?:POSITION|INSTR|LOCATE)\s*\(/,
+    helper => 'sql_position/sql_iposition',
+    message => 'use $dbh->sql_position(...) or $dbh->sql_iposition(...) instead',
+  },
+  {
+    token => qr/\bGROUP_CONCAT\s*\(/,
+    helper => 'sql_group_concat',
+    message => 'use $dbh->sql_group_concat(...) instead of GROUP_CONCAT()',
+  },
+);
+
+my @violations;
+
+foreach my $file (@files) {
+  next if $file =~ m{^Bugzilla/DB(?:/|\.pm$)};
+
+  open(my $fh, '<', $file) or do {
+    push @violations, { file => $file, line => 0, text => 'could not open file' };
+    next;
+  };
+
+  my $line_number = 0;
+  while (my $line = <$fh>) {
+    $line_number++;
+    next if $line =~ /^\s*#/;
+    next if $line =~ /^\s*=/;
+
+    foreach my $rule (@rules) {
+      next unless $line =~ $rule->{token};
+      push @violations, {
+        file    => $file,
+        line    => $line_number,
+        text    => $line,
+        helper  => $rule->{helper},
+        message => $rule->{message},
+      };
+    }
+  }
+  close($fh);
+}
+
+is(scalar(@violations), 0, 'no raw vendor-specific SQL where a Bugzilla DB helper exists');
+
+if (@violations) {
+  diag(join("\n", map {
+    sprintf('%s:%d: %s (%s)', $_->{file}, $_->{line}, $_->{message}, $_->{text})
+  } @violations));
+}
+
+done_testing();


### PR DESCRIPTION
#### Details
Tests perl code for vendor-specific SQL where we have db-agnostic helper methods available

#### Additional info
* [bug#2054397](https://bugzilla.mozilla.org/show_bug.cgi?id=2054397)

#### Test Plan
1. `bash docker/run-tests-in-docker.sh release prove -lv t/013db_portability.t`
2. Look at test results.

The initial run produced the following output:

```
#   Failed test 'no raw vendor-specific SQL where a Bugzilla DB helper exists'
#   at t/013db_portability.t line 80.
#          got: '7'
#     expected: '0'
# Bugzilla/Report/SecurityRisk.pm:291: use $dbh->sql_string_concat(...) instead of CONCAT() (            CONCAT(removed) AS removed,
# )
# Bugzilla/Report/SecurityRisk.pm:292: use $dbh->sql_string_concat(...) instead of CONCAT() (            CONCAT(added) AS added
# )
# extensions/BMO/lib/Reports/Triage.pm:317: use $dbh->sql_string_concat(...) instead of CONCAT() (                    WHERE  bugs_1.bug_id = bugs.bug_id AND CONCAT(flagtypes_1.name, flags_1.status) = 'needinfo?')))
# )
# extensions/BMO/lib/Reports/UserActivity.pm:185: use $dbh->sql_date_format(...) instead of DATE_FORMAT() (                   DATE_FORMAT(longdescs.bug_when, '%Y-%m-%d %H:%i:%s') AS ts,
# )
# extensions/BugModal/lib/ActivityStream.pm:361: use $dbh->sql_date_format(...) instead of UNIX_TIMESTAMP() (               UNIX_TIMESTAMP(bug_when), " . $dbh->sql_date_format('bug_when') . ",
# )
# extensions/ProdCompSearch/lib/WebService.pm:210: use $dbh->sql_string_concat(...) instead of CONCAT() (      "CONCAT(products.name, components.name) LIKE "
# )
# extensions/UserProfile/lib/Util.pm:250: use $dbh->sql_string_concat(...) instead of CONCAT() (    SELECT CONCAT('RESOLVED/', added) AS status, COUNT(*) AS count
# )
# Looks like you failed 1 test of 1.
t/013db_portability.t .. 
not ok 1 - no raw vendor-specific SQL where a Bugzilla DB helper exists
1..1
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/1 subtests 

Test Summary Report
-------------------
t/013db_portability.t (Wstat: 256 (exited 1) Tests: 1 Failed: 1)
  Failed test:  1
  Non-zero exit status: 1
Files=1, Tests=1,  1 wallclock secs ( 0.01 usr  0.01 sys +  0.29 cusr  0.11 csys =  0.42 CPU)
Result: FAIL
```

And this PR should fail tests for the same reason.  Second commit will fix the failures.