### PR TITLE
Bug 2054399: pull dependencies from extensions in TestSuite Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
 
   test_release:
     name: Perl Test Suite
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Build Docker image
         run: docker buildx build --load -t bugzilla-release-test -f docker/images/Dockerfile.perl-testsuite .
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,12 +86,14 @@ jobs:
 
   test_release:
     name: Perl Test Suite
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Build Docker image
-        run: docker build -t bugzilla-release-test -f docker/images/Dockerfile.perl-testsuite .
+        run: docker buildx build --load -t bugzilla-release-test -f docker/images/Dockerfile.perl-testsuite .
       - name: Run tests
         run: docker run --rm bugzilla-release-test
 

--- a/docker/images/Dockerfile.perl-testsuite
+++ b/docker/images/Dockerfile.perl-testsuite
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get -y dist-upgrade && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy just enough to get the list of dependencies
-COPY Bugzilla.pm Makefile.PL gen-cpanfile.pl /app/
+COPY --parents Bugzilla.pm Makefile.PL gen-cpanfile.pl extensions/*/Config.pm extensions/*/disabled /app/
 
 # Run Makefile.PL and install dependencies
 RUN perl Makefile.PL && \

--- a/docker/images/Dockerfile.perl-testsuite
+++ b/docker/images/Dockerfile.perl-testsuite
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
#### Details
If an extension added additional dependencies, the image build wasn't picking them up.

#### Additional info
* [bug#2054399](https://bugzilla.mozilla.org/show_bug.cgi?id=2054399)

#### Test Plan
1. `rm extensions/SecureMail/disabled`
2. `bash docker/run-tests-in-docker.sh release`
3.  The docker image should actually build and the tests should run.

#### Additional Info

Apparently GitHub provides Docker to its ubuntu-* images as a host-side daemon, and the one they provide is too old to handle `COPY --parents`, so this PR also updates the test invocation to use Docker Buildx, which is a GitHub Action provided by Docker to let you run the current version of Docker for the build phase instead of using the GitHub-provided one. I believe it's still using the GitHub-provided one to actually run the image (it hands it off after building it).