### PR TITLE
[harmony] Bug 2051802: Abort UTF8 conversion without an explicit override

### DIFF
--- a/Bugzilla/DB/MariaDB.pm
+++ b/Bugzilla/DB/MariaDB.pm
@@ -655,14 +655,19 @@ sub bz_setup_database {
   if (Bugzilla->params->{'utf8'} && $non_utf8_tables) {
     print "\n", install_string('mysql_utf8_conversion');
 
-    if (!Bugzilla->installation_answers->{NO_PAUSE}) {
-      if (Bugzilla->installation_mode == INSTALLATION_MODE_NON_INTERACTIVE) {
-        die install_string('continue_without_answers'), "\n";
-      }
-      else {
-        print "\n         " . install_string('enter_or_ctrl_c');
-        getc;
-      }
+    my $allow_unsafe_utf8_conversion
+      = Bugzilla->installation_answers->{ALLOW_UNSAFE_UTF8_CONVERSION};
+    if ($allow_unsafe_utf8_conversion) {
+      print "\n"
+        . install_string('continuing_with_unsafe_utf8_conversion')
+        . "\n";
+    }
+    elsif (Bugzilla->installation_mode == INSTALLATION_MODE_NON_INTERACTIVE) {
+      die install_string('continue_without_answers'), "\n";
+    }
+    else {
+      print "\n         " . install_string('enter_or_ctrl_c');
+      getc;
     }
 
     print

--- a/Bugzilla/DB/Mysql.pm
+++ b/Bugzilla/DB/Mysql.pm
@@ -657,14 +657,19 @@ sub bz_setup_database {
   if (Bugzilla->params->{'utf8'} && $non_utf8_tables) {
     print "\n", install_string('mysql_utf8_conversion');
 
-    if (!Bugzilla->installation_answers->{NO_PAUSE}) {
-      if (Bugzilla->installation_mode == INSTALLATION_MODE_NON_INTERACTIVE) {
-        die install_string('continue_without_answers'), "\n";
-      }
-      else {
-        print "\n         " . install_string('enter_or_ctrl_c');
-        getc;
-      }
+    my $allow_unsafe_utf8_conversion
+      = Bugzilla->installation_answers->{ALLOW_UNSAFE_UTF8_CONVERSION};
+    if ($allow_unsafe_utf8_conversion) {
+      print "\n"
+        . install_string('continuing_with_unsafe_utf8_conversion')
+        . "\n";
+    }
+    elsif (Bugzilla->installation_mode == INSTALLATION_MODE_NON_INTERACTIVE) {
+      die install_string('continue_without_answers'), "\n";
+    }
+    else {
+      print "\n         " . install_string('enter_or_ctrl_c');
+      getc;
     }
 
     print

--- a/conf/checksetup_answers.txt
+++ b/conf/checksetup_answers.txt
@@ -4,6 +4,8 @@ $answer{'ADMIN_PASSWORD'}       = 'password01!';
 $answer{'passwdqc_min'}         = '8, 8, 8, 8, 8';
 $answer{'ADMIN_REALNAME'}       = 'Vagrant User';
 $answer{'NO_PAUSE'}             = 1;
+$answer{'ALLOW_UNSAFE_UTF8_CONVERSION'}
+	= $ENV{'BZ_ALLOW_UNSAFE_UTF8_CONVERSION'} ? 1 : 0;
 $answer{'size_limit'}           = 750000;
 $answer{'bugzilla_version'}     = '1';
 $answer{'create_htaccess'}      = '1';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - BMO_ses_password=password123456789!
       - BMO_urlbase=http://127.0.0.1:8000/
       - BUGZILLA_ALLOW_INSECURE_HTTP=1
+      - BZ_ALLOW_UNSAFE_UTF8_CONVERSION=${BZ_ALLOW_UNSAFE_UTF8_CONVERSION:-0}
       - BZ_ANSWERS_FILE=/app/conf/checksetup_answers.txt
       - HTTP_BACKEND=morbo
       - LOCALCONFIG_ENV=1

--- a/docker/README.md
+++ b/docker/README.md
@@ -63,6 +63,14 @@ Currently, the entry point takes a single command argument. This can be
     This should never be set in production. It allows auth delegation
     and oauth over http.
 
+  - BZ\_ALLOW\_UNSAFE\_UTF8\_CONVERSION
+    Controls whether checksetup may proceed with the database UTF-8
+    conversion in non-interactive mode. Default: 0.
+
+    Set this to 1 only when you explicitly approve the conversion and
+    have a database backup. For example:
+    `BZ_ALLOW_UNSAFE_UTF8_CONVERSION=1 docker compose up`
+
   - BMO\_urlbase  
     The public URL for this instance. Note that if this begins with
     <https://> and BMO\_inbound\_proxies is set to '\*' Bugzilla will

--- a/template/en/default/setup/strings.txt.pl
+++ b/template/en/default/setup/strings.txt.pl
@@ -56,6 +56,13 @@ EOT
   continue_without_answers => <<'END',
 Re-run checksetup.pl in interactive mode (without an 'answers' file)
 to continue.
+
+To continue non-interactively, set ALLOW_UNSAFE_UTF8_CONVERSION to 1
+in your answers file.
+END
+  continuing_with_unsafe_utf8_conversion => <<'END',
+WARNING: ALLOW_UNSAFE_UTF8_CONVERSION is enabled. Continuing the UTF-8
+         conversion without an interactive confirmation prompt.
 END
   cpanfile_created   => "##file## created",
   cpan_bugzilla_home => "WARNING: Using the Bugzilla directory as the CPAN home.",


### PR DESCRIPTION
#### Details
When Docker hits the non-interactive UTF-8 conversion bailout, console output now prints a clear hint showing how to proceed explicitly:

BZ_ALLOW_UNSAFE_UTF8_CONVERSION=1 docker compose up

What changed

1. Removed the NO_PAUSE gating on the UTF8 conversion to force it to bail even if NO_PAUSE is active
2. New Docker env var is wired into the generated answers file
3. Checksetup DB code now honors ALLOW_UNSAFE_UTF8_CONVERSION=1 in non-interactive mode (instead of always dying at that point)
4. User-facing setup text updated to document the answers-file override
5. Docker quick-start README note added: bugzilla/README

Net effect

1. If you do nothing, behavior stays safe (default is 0, so it still blocks).
2. If you explicitly opt in, conversion runs non-interactively.
3. If conversion blocks and exits, Docker no longer pretends setup succeeded.

#### Additional info
* [bug#2051802](https://bugzilla.mozilla.org/show_bug.cgi?id=2051802)

#### Test Plan
1. Ran `docker compose up`
2. After it came up, used the Files tab in Docker Desktop to drop a database dump from 5.06 into the root directory on the MySQL container
3. Used the Exec tab in Docker Desktop to open a shell and restore that dump into the database.
4. Ran `docker compose down`
5. Ran `docker compose up` and verified that the conversion bailed with the new messaging.
6. Ran `ALLOW_UNSAFE_UTF8_CONVERSION=1 docker compose up` and verified that the conversion proceeded.
