### PR TITLE
Bug 1962909: less-confusing verbiage about the expiration date in new account emails

### DIFF
--- a/template/en/default/account/email/request-new.txt.tmpl
+++ b/template/en/default/account/email/request-new.txt.tmpl
@@ -34,7 +34,7 @@ following link by [% expiration_ts FILTER time("%B %e, %Y at %H:%M %Z") %]:
 
 [%+ urlbase %]token.cgi?t=[% token FILTER uri %]&a=request_new_account
 
-If you did not receive this email before [% expiration_ts FILTER time("%B %e, %Y at %H:%M %Z") %] or
+If you did not visit the above link by [% expiration_ts FILTER time("%B %e, %Y at %H:%M %Z") %] or
 you wish to create an account using a different email address you can begin
 again by going to:
 


### PR DESCRIPTION
#### Details
Fix the text in the new account emails to be less confusing.
Harmony port of bugzilla/bugzilla#239.

#### Additional info
* [bug#1962909](https://bugzilla.mozilla.org/show_bug.cgi?id=1962909)