### PR TITLE
Bug 889650: Fix crash when searching "match all of the same field" on Flags

### DIFF
--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -3219,7 +3219,7 @@ sub _flagtypes_nonchanged {
   # don't call build_subselect as this must run as a true sub-select
   $args->{term} = "EXISTS (
         SELECT 1
-          FROM $bugs_table bugs_$chart_id
+	  FROM bugs bugs_$chart_id
           LEFT JOIN attachments AS attachments_$chart_id
                     ON bugs_$chart_id.bug_id = attachments_$chart_id.bug_id
           LEFT JOIN flags AS flags_$chart_id

--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -3219,7 +3219,7 @@ sub _flagtypes_nonchanged {
   # don't call build_subselect as this must run as a true sub-select
   $args->{term} = "EXISTS (
         SELECT 1
-	  FROM bugs bugs_$chart_id
+          FROM bugs bugs_$chart_id
           LEFT JOIN attachments AS attachments_$chart_id
                     ON bugs_$chart_id.bug_id = attachments_$chart_id.bug_id
           LEFT JOIN flags AS flags_$chart_id

--- a/xt/lib/Bugzilla/Test/Search/Constants.pm
+++ b/xt/lib/Bugzilla/Test/Search/Constants.pm
@@ -1257,6 +1257,15 @@ use constant CUSTOM_SEARCH_TESTS => (
     ]
   },
 
+  {
+    name       => 'flagtypes.name = <1> AND flagtypes.name = <1>',
+    contains   => [1],
+    top_params => {j_top => 'AND_G'},
+    params     => [
+      {f => 'flagtypes.name', o => 'equals', v => '<1>'},
+      {f => 'flagtypes.name', o => 'equals', v => '<1>'},
+    ]
+  },
 );
 
 1;


### PR DESCRIPTION
#### Details
Harmony port of bugzilla/bugzilla#237. The grouped flag search in
_flagtypes_nonchanged was reading from $bugs_table, which has already been
reassigned to the grouped alias at that point, so the subquery referenced a
bugs_g2 table that does not exist. Reads from the real bugs table instead.

Also adds the matching regression test to CUSTOM_SEARCH_TESTS.

#### Additional info
* [bug#889650](https://bugzilla.mozilla.org/show_bug.cgi?id=889650)