### PR TITLE
Bug 2059616: enable readable-status unconditionally

### DIFF
--- a/extensions/BugModal/Extension.pm
+++ b/extensions/BugModal/Extension.pm
@@ -25,13 +25,6 @@ use JSON::XS qw(encode_json);
 
 our $VERSION = '1';
 
-use constant READABLE_BUG_STATUS_PRODUCTS => (
-  'Core',            'Toolkit',
-  'Firefox',         'Firefox for Android',
-  'Firefox for iOS', 'Bugzilla',
-  'bugzilla.mozilla.org'
-);
-
 sub show_bug_format {
   my ($self, $args) = @_;
   $args->{format} = _alternative_show_bug_format();
@@ -201,24 +194,24 @@ sub template_before_process {
     file => 'bug/edit.html.tmpl', vars => $vars,
   });
 
-  if (any { $bug->product eq $_ } READABLE_BUG_STATUS_PRODUCTS) {
-    my @flags = map { {name => $_->name, status => $_->status} } @{$bug->flags};
-    $vars->{readable_bug_status_json} = encode_json({
-      dupe_of          => $bug->dup_id,
-      id               => $bug->id,
-      keywords         => [map { $_->name } @{$bug->keyword_objects}],
-      priority         => $bug->priority,
-      resolution       => $bug->resolution,
-      status           => $bug->bug_status,
-      flags            => \@flags,
-      target_milestone => $bug->target_milestone,
-      map { $_->name => $_->bug_flag($bug->id)->value } @{$vars->{tracking_flags}},
-    });
-
-    # HTML4 attributes cannot be longer than this, so just skip it in this case.
-    if (length($vars->{readable_bug_status_json}) > 65536) {
-      delete $vars->{readable_bug_status_json};
-    }
+  # bugzilla-readable-status
+  my @flags = map { {name => $_->name, status => $_->status} } @{$bug->flags};
+  $vars->{readable_bug_status_json} = encode_json({
+    dupe_of          => $bug->dup_id,
+    id               => $bug->id,
+    keywords         => [map { $_->name } @{$bug->keyword_objects}],
+    priority         => $bug->priority,
+    resolution       => $bug->resolution,
+    status           => $bug->bug_status,
+    flags            => \@flags,
+    target_milestone => $bug->target_milestone,
+    Bugzilla->has_extension('TrackingFlags')
+    ? map { $_->name => $_->bug_flag($bug->id)->value } @{$vars->{tracking_flags}}
+    : {},
+  });
+  # HTML4 attributes cannot be longer than this, so just skip it in this case.
+  if (length($vars->{readable_bug_status_json}) > 65536) {
+    delete $vars->{readable_bug_status_json};
   }
 
   # bug->choices loads a lot of data that we want to lazy-load

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -92,46 +92,6 @@
       END;
     END;
   END;
-
-  # build Firefox flags subtitle
-  firefox_flags = [];
-  firefox_fixed_versions = [];
-  # project flags
-  FOREACH row IN tracking_flags_table;
-    NEXT UNLESS row.type == "project";
-    status_value = row.status.bug_flag(bug.id).value;
-    NEXT IF status_value == "---";
-    firefox_flags.push(row.name _ ":" _ status_value);
-  END;
-  # tracking flags title and subtitle
-  FOREACH row IN tracking_flags_table;
-    NEXT UNLESS row.type == "tracking";
-    tracking_value = row.tracking ? row.tracking.bug_flag(bug.id).value : "---";
-    status_value = row.status.bug_flag(bug.id).value || "---";
-    NEXT IF tracking_value == "---" && status_value == "---";
-    blurb = row.name;
-    IF tracking_value != "---";
-      blurb = blurb _ tracking_value;
-    END;
-    IF status_value != "---";
-      blurb = blurb _ " " _ status_value;
-      IF status_value == "fixed" || status_value == "verified";
-        flag_name = row.name;
-        IF flag_name.substr(0, 7) == "firefox";
-          IF firefox_fixed_versions.0 == "";
-            firefox_fixed_versions.0 = "Firefox " _ flag_name.substr(7);
-          END;
-        END;
-      END;
-    END;
-    firefox_flags.push(blurb);
-  END;
-  firefox_fixed_version = firefox_fixed_versions.join(", ");
-  IF firefox_flags.size;
-    firefox_flags_subtitle = firefox_flags.join(", ");
-  ELSE;
-    firefox_flags_subtitle = "Not tracked";
-  END;
 %]
 
 [% IF user.id %]
@@ -550,7 +510,7 @@
   [% END %]
   [% sub = [{ unfiltered = readable_bug_status_span }] %]
 [% ELSE %]
-  [% sub = [firefox_flags_subtitle] %]
+  [% sub = ["Not tracked"] %]
 [% END %]
 [% WRAPPER bug_modal/module.html.tmpl
   title = "Tracking"


### PR DESCRIPTION
#### Details
This was originally PR #74 but that got backed out.  This is resurrecting the patch from that PR.

#### Additional info
* [bug#2059616](https://bugzilla.mozilla.org/show_bug.cgi?id=2059616)

## PR Review Context for Copilot

### Goal
Enable readable status output in BugModal for all products (not just Mozilla-specific ones), so the Tracking section subtitle provides a useful plain-English summary everywhere.

### Background and History
A very similar change landed on harmony before and was backed out just before the 5.9.1 release because it broke the tree.

Reported historical breakage cause:
- Calling has_extension(), which does not exist in this harmony codebase.

Some dependencies may have changed since then, but this patch should still be reviewed with that prior failure mode in mind.

### Important Runtime Assumptions
TrackingFlags ships with harmony, but admins may disable it.

This patch should therefore work in both scenarios:
1. TrackingFlags enabled
2. TrackingFlags installed but disabled/unavailable at runtime

### Intended Behavior Change
Remove Mozilla-only gating around readable status generation and make readable status available generally in BugModal.

The Tracking subtitle should still have a sensible fallback when readable status data cannot be generated.

### What Reviewers Should Check Closely

1. Non-existent API usage
- Ensure no use of Bugzilla->has_extension() (or equivalent nonexistent API) on harmony.

2. Optional extension safety
- Any TrackingFlags interaction should be guarded so BugModal still renders if TrackingFlags is disabled.

3. Perl data construction correctness
- Conditional inclusion of tracking-derived fields in readable status JSON must add valid key/value pairs (or nothing), not a hashref scalar where key/value list entries are expected.

4. Subtitle fallback correctness
- If readable JSON is unavailable (for example oversized attribute or optional dependency unavailable), fallback text should not be misleading.

5. Branch fit
- This is a harmony-targeted robustness/compatibility and UX consistency change, not a Mozilla-only feature path.

### Reviewer Intent
Please review this patch as an always-on readable-status change with emphasis on:
- runtime compatibility on harmony
- safe behavior with TrackingFlags disabled
- avoiding the prior tree-break pattern