### PR TITLE
[harmony] Bug 2066699: Add extension hook: user_preferences_settings

### DIFF
--- a/Bugzilla/Hook.pm
+++ b/Bugzilla/Hook.pm
@@ -1627,6 +1627,24 @@ name), you can get it from here.
 
 =back
 
+=head2 user_preferences_settings
+
+This hook allows extensions to exclude settings from the General Settings tab
+in User Preferences, for example if the extension is managing them using
+custom UI. It is called while displaying the settings and while saving them,
+so excluded settings are neither displayed nor updated by that tab.
+
+Params:
+
+=over
+
+=item C<skip_settings>
+
+A hashref whose keys are setting names. Set the value for a setting name to a
+true value to exclude that setting from the General Settings tab.
+
+=back
+
 =head2 user_preferences
 
 This hook allows you to add additional panels to the User Preferences page,

--- a/extensions/Example/Extension.pm
+++ b/extensions/Example/Extension.pm
@@ -949,6 +949,14 @@ sub template_before_process {
   }
 }
 
+sub user_preferences_settings {
+  my ($self, $args) = @_;
+
+  # Exclude this setting from the General Settings tab when the extension
+  # provides its own UI for managing it.
+  $args->{skip_settings}->{example_pref} = 1;
+}
+
 sub user_preferences {
   my ($self, $args) = @_;
   my $tab     = $args->{current_tab};

--- a/userprefs.cgi
+++ b/userprefs.cgi
@@ -230,10 +230,14 @@ sub DoSettings {
   my $user = Bugzilla->user;
 
   my %settings;
+  my %skip_settings;
+  Bugzilla::Hook::process('user_preferences_settings',
+    {skip_settings => \%skip_settings});
   my $has_settings_enabled = 0;
   foreach my $name (sort keys %{$user->settings}) {
     my $setting = $user->settings->{$name};
     next if !$setting->{is_enabled};
+    next if $skip_settings{$name};
     my $category = $setting->{category};
     $settings{$category} ||= [];
     push(@{$settings{$category}}, $setting);
@@ -253,8 +257,13 @@ sub SaveSettings {
   my @setting_list = keys %$settings;
   my $mfa_event    = undef;
 
+  my %skip_settings;
+  Bugzilla::Hook::process('user_preferences_settings',
+    {skip_settings => \%skip_settings});
+
   foreach my $name (@setting_list) {
     next if !($settings->{$name}->{'is_enabled'});
+    next if $skip_settings{$name};
     my $value = $cgi->param($name);
     next unless defined $value;
     my $setting = new Bugzilla::User::Setting($name);


### PR DESCRIPTION
#### Details
Extension can add setting names to the `%skip_settings` hash to exclude them from the General Settings tab in User Preferences (for example if it will be managing them with custom UI from an additional settings tab).

#### Additional info
* [bug#2066699](https://bugzilla.mozilla.org/show_bug.cgi?id=2066699)

#### Test Plan
#156 will make use of this once it lands